### PR TITLE
Pensieve external config integration

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -4,6 +4,8 @@ set -e
 
 if [ "$1" = "export_statistics_to_json" ]; then
     exec pensieve export-statistics-to-json
+elif [ "$1" = "rerun_config_changed" ]; then
+    exec pensieve rerun_config_changed
 else
-    exec pensieve run "$@"
+    exec pensieve run "$@" --rerun-config-changed=true
 fi

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -3,10 +3,10 @@
 set -e
 
 if [ "$1" = "export_statistics_to_json" ]; then
-    exec pensieve export-statistics-to-json
+    pensieve export-statistics-to-json
 elif [ "$1" = "rerun_config_changed" ]; then
-    exec pensieve rerun_config_changed
+    pensieve rerun_config_changed
 else
-    exec pensieve run "$@"
-    exec pensieve rerun_config_changed
+    pensieve run "$@"
+    pensieve rerun_config_changed
 fi

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -7,5 +7,6 @@ if [ "$1" = "export_statistics_to_json" ]; then
 elif [ "$1" = "rerun_config_changed" ]; then
     exec pensieve rerun_config_changed
 else
-    exec pensieve run "$@" --rerun-config-changed=true
+    exec pensieve run "$@"
+    exec pensieve rerun_config_changed
 fi

--- a/pensieve/cli.py
+++ b/pensieve/cli.py
@@ -132,7 +132,7 @@ def run_cmd(
     project_id, dataset_id, date, experiment_slug, dry_run, config_file, rerun_config_changed
 ):
     """CLI command for running analyses on active experiments."""
-    run(project_id, dataset_id, date, experiment_slug, dry_run, config_file)
+    run(project_id, dataset_id, date, experiment_slug, dry_run, config_file, rerun_config_changed)
 
 
 def rerun(project_id, dataset_id, experiment_slug, dry_run, config_file):
@@ -187,12 +187,12 @@ def rerun_config_changed(project_id, dataset_id, dry_run):
     """Rerun all available analyses for experiments with new or updated config files."""
     # get experiment-specific external configs
     external_configs = ExternalConfigCollection.from_github_repo()
-    for external_config in external_configs:
+    for external_config in external_configs.configs:
         if external_config.updated(project_id, dataset_id):
             rerun(project_id, dataset_id, external_config.normandy_slug, dry_run)
 
 
-@cli.command()
+@cli.command("rerun_config_changed")
 @project_id_option
 @dataset_id_option
 @dry_run_option

--- a/pensieve/cli.py
+++ b/pensieve/cli.py
@@ -76,6 +76,7 @@ secret_config_file_option = click.option(
 bucket_option = click.option("--bucket", default="mozanalysis", help="GCS bucket to write to")
 
 
+@cli.command()
 @project_id_option
 @dataset_id_option
 @click.option(
@@ -154,6 +155,7 @@ def rerun(project_id, dataset_id, experiment_slug, dry_run, config_file):
     config = spec.resolve(experiment)
 
     for date in inclusive_date_range(experiment.start_date, end_date):
+        logging.info(f"*** {date}")
         Analysis(project_id, dataset_id, config).run(date, dry_run=dry_run)
 
 

--- a/pensieve/cli.py
+++ b/pensieve/cli.py
@@ -179,6 +179,7 @@ def export_statistics_to_json(project_id, dataset_id, bucket):
     export_statistics_tables(project_id, dataset_id, bucket)
 
 
+@cli.command("rerun_config_changed")
 @project_id_option
 @dataset_id_option
 @dry_run_option

--- a/pensieve/config.py
+++ b/pensieve/config.py
@@ -161,7 +161,9 @@ class ExperimentConfiguration:
         if self.experiment_spec.enrollment_query is None:
             return None
 
-        if cached := getattr(self, "_enrollment_query", None):
+        cached = getattr(self, "_enrollment_query", None)
+
+        if cached:
             return cached
 
         class ExperimentProxy:

--- a/pensieve/external_config.py
+++ b/pensieve/external_config.py
@@ -7,9 +7,10 @@ Experiment-specific configuration files are stored in https://github.com/mozilla
 import datetime as dt
 import attr
 from github import Github
+from google.cloud import bigquery
 import os
 import toml
-from typing import List
+from typing import List, Optional
 
 from pensieve.config import AnalysisSpec
 
@@ -21,6 +22,28 @@ class ExternalConfig:
     normandy_slug: str
     spec: AnalysisSpec
     last_modified: dt.datetime
+
+    def updated(self, bq_project: str, bq_dataset: str) -> bool:
+        """
+        Check whether the config file has been updated/added and
+        associated BigQuery tables are out of date.
+        """
+        client = bigquery.Client(bq_project, bq_dataset)
+        job = client.query(
+            f"""
+            SELECT COUNT(*) AS n FROM {bq_dataset}.__TABLES__
+            WHERE table_id LIKE '{self.normandy_slug}%'
+            AND TIMESTAMP_MILLIS(last_modified_time) <
+                '{dt.strptime(self.last_modified, "%Y-%m-%d %H:%M:%s")}'
+        """
+        )
+
+        result = job.result()
+        for row in result:
+            if row.n > 0:
+                return True
+
+        return False
 
 
 @attr.s(auto_attribs=True)
@@ -35,7 +58,7 @@ class ExternalConfigCollection:
     PENSIEVE_CONFIG_REPO = "mozilla/pensieve-config"
 
     @classmethod
-    def from_github_repo(cls):
+    def from_github_repo(cls) -> "ExternalConfigCollection":
         """Pull in external config files."""
 
         g = Github()
@@ -52,7 +75,7 @@ class ExternalConfigCollection:
 
         return cls(configs)
 
-    def spec_for_experiment(self, normandy_slug):
+    def spec_for_experiment(self, normandy_slug: str) -> Optional[AnalysisSpec]:
         """Return the spec for a specific experiment."""
         for config in self.configs:
             if config.normandy_slug == normandy_slug:

--- a/pensieve/external_config.py
+++ b/pensieve/external_config.py
@@ -8,6 +8,7 @@ import datetime as dt
 import attr
 from dateutil import parser
 from github import Github
+from github.ContentFile import ContentFile
 from google.cloud import bigquery
 import os
 import re
@@ -67,13 +68,16 @@ class ExternalConfigCollection:
         repo = g.get_repo(cls.PENSIEVE_CONFIG_REPO)
         files = repo.get_contents("")
 
+        if isinstance(files, ContentFile):
+            files = [files]
+
         configs = []
 
         for file in files:
             if file.name.endswith(".toml"):
                 normandy_slug = os.path.splitext(file.name)[0]
                 spec = AnalysisSpec.from_dict(toml.loads(file.decoded_content.decode("utf-8")))
-                last_modified = parser.parse(file.last_modified)
+                last_modified = parser.parse(str(file.last_modified))
                 configs.append(ExternalConfig(normandy_slug, spec, last_modified))
 
         return cls(configs)

--- a/pensieve/external_config.py
+++ b/pensieve/external_config.py
@@ -36,7 +36,7 @@ class ExternalConfigCollection:
 
     configs: List[ExternalConfig] = attr.Factory(list)
 
-    PENSIEVE_CONFIG_REPO = "mozilla/pensieve-config"
+    PENSIEVE_CONFIG_REPO = "mozilla/jetstream-config"
 
     @classmethod
     def from_github_repo(cls) -> "ExternalConfigCollection":

--- a/pensieve/external_config.py
+++ b/pensieve/external_config.py
@@ -1,0 +1,52 @@
+"""
+Retrieves external configuration files for specific experiments.
+
+Experiment-specific configuration files are stored in https://github.com/mozilla/pensieve-config/ 
+"""
+
+import datetime as dt
+
+import attr
+import cattr
+from github import Github
+import os
+import pytz
+import requests
+from typing import List
+
+
+@attr.s(auto_attribs=True)
+class ExternalConfig:
+    """Represent an external config file."""
+    normandy_slug: str 
+    content: str
+    last_modified: dt.datetime
+
+
+@attr.s(auto_attribs=True)
+class ExternalConfigCollection:
+    """
+    Collection of experiment-specific configurations pulled in
+    from an external GitHub repository.
+    """
+    configs: List[ExternalConfig] = attr.Factory(list)
+
+    PENSIEVE_CONFIG_REPO = "mozilla/pensieve-config"
+
+    @classmethod
+    def from_github_repo(cls):
+        """Pull in external config files."""
+
+        g = Github()
+        repo = g.get_repo(cls.PENSIEVE_CONFIG_REPO)
+        files = repo.get_contents("")
+
+        configs = []
+
+        for file in files:
+            if file.name.endswith(".toml"):
+                normandy_slug = os.path.splitext(file.name)[0]
+                configs.append(ExternalConfig(normandy_slug, file.decoded_content, file.last_modified))
+
+        return cls(configs)
+

--- a/pensieve/tests/integration/test_external_config_integration.py
+++ b/pensieve/tests/integration/test_external_config_integration.py
@@ -1,4 +1,3 @@
-from google.cloud import bigquery
 from pathlib import Path
 import datetime
 import pytest

--- a/pensieve/tests/integration/test_external_config_integration.py
+++ b/pensieve/tests/integration/test_external_config_integration.py
@@ -1,0 +1,94 @@
+from google.cloud import bigquery
+from pathlib import Path
+import datetime
+import pytest
+import random
+import string
+from textwrap import dedent
+import toml
+import time
+
+from pensieve.external_config import ExternalConfig
+from pensieve.config import AnalysisSpec
+
+TEST_DIR = Path(__file__).parent.parent
+
+
+class TestExternalConfigIntegration:
+    project_id = "pensieve-integration-test"
+
+    # generate a random test dataset to avoid conflicts when running tests in parallel
+    test_dataset = "test_" + "".join(random.choice(string.ascii_lowercase) for i in range(10))
+    # contains the tables filled with test data required to run metrics analysis
+    static_dataset = "test_data"
+
+    config_str = dedent(
+        """
+        [metrics]
+        weekly = ["view_about_logins"]
+
+        [metrics.view_about_logins.statistics.bootstrap_mean]
+        """
+    )
+    spec = AnalysisSpec.from_dict(toml.loads(config_str))
+
+    @pytest.fixture(scope="class")
+    def client(self):
+        self._client = getattr(self, "_client", None) or bigquery.client.Client(self.project_id)
+        return self._client
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        # remove all tables previously created
+
+        client.delete_dataset(self.test_dataset, delete_contents=True, not_found_ok=True)
+        client.create_dataset(self.test_dataset)
+
+    def test_new_config(self, client):
+        config = ExternalConfig(
+            normandy_slug="new_experiment", spec=self.spec, last_modified=datetime.datetime.utcnow()
+        )
+
+        assert config.updated(self.project_id, self.test_dataset) is False
+
+    def test_old_config(self, client):
+        config = ExternalConfig(
+            normandy_slug="new_table",
+            spec=self.spec,
+            last_modified=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        )
+
+        # table created after config loaded
+        client.create_table(f"{self.test_dataset}.new_table_day1")
+
+        assert config.updated(self.project_id, self.test_dataset) is False
+
+    def test_updated_config(self, client):
+        config = ExternalConfig(
+            normandy_slug="old_table",
+            spec=self.spec,
+            last_modified=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+        )
+
+        client.create_table(f"{self.test_dataset}.old_table_day1")
+        client.create_table(f"{self.test_dataset}.old_table_day2")
+
+        assert config.updated(self.project_id, self.test_dataset) is True
+
+    def test_updated_config_while_analysis_active(self, client):
+        client.create_table(f"{self.test_dataset}.old_table_day1")
+
+        client.create_table(f"{self.test_dataset}.active_table_day0")
+        client.create_table(f"{self.test_dataset}.active_table_day1")
+        time.sleep(10)
+
+        config = ExternalConfig(
+            normandy_slug="active_table", spec=self.spec, last_modified=datetime.datetime.utcnow()
+        )
+
+        time.sleep(10)
+
+        client.create_table(f"{self.test_dataset}.active_table_day2")
+        client.create_table(f"{self.test_dataset}.active_table_weekly")
+
+        assert config.updated(self.project_id, self.test_dataset) is True

--- a/pensieve/tests/test_external_config.py
+++ b/pensieve/tests/test_external_config.py
@@ -1,6 +1,12 @@
 from pensieve.external_config import ExternalConfigCollection
 
 
-class TestExterinalConfig:
+class TestExternalConfig:
     def test_from_github_repo(self):
-        assert ExternalConfigCollection.from_github_repo()
+        external_configs = ExternalConfigCollection.from_github_repo()
+        assert external_configs
+
+        example_conf = external_configs.spec_for_experiment("example_config")
+        assert example_conf is not None
+
+        assert external_configs.spec_for_experiment("not-existing-conf") is None

--- a/pensieve/tests/test_external_config.py
+++ b/pensieve/tests/test_external_config.py
@@ -1,6 +1,6 @@
-from pensieve.external_config import ExternalConfigCollection 
+from pensieve.external_config import ExternalConfigCollection
+
 
 class TestExterinalConfig:
     def test_from_github_repo(self):
         assert ExternalConfigCollection.from_github_repo()
-

--- a/pensieve/tests/test_external_config.py
+++ b/pensieve/tests/test_external_config.py
@@ -1,0 +1,6 @@
+from pensieve.external_config import ExternalConfigCollection 
+
+class TestExterinalConfig:
+    def test_from_github_repo(self):
+        assert ExternalConfigCollection.from_github_repo()
+

--- a/requirements.in
+++ b/requirements.in
@@ -44,6 +44,7 @@ pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
+PyGithub==1.51            # via mozilla-pensieve
 pyparsing==2.4.7          # via packaging
 pytest-black==0.3.9       # via mozilla-pensieve
 pytest-cov==2.10.0        # via mozilla-pensieve

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,6 +77,10 @@ coverage==5.1 \
     --hash=sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489 \
     --hash=sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052 \
     # via -r requirements.in, pytest-cov
+deprecated==1.2.10 \
+    --hash=sha256:525ba66fb5f90b07169fdd48b6373c18f1ee12728ca277ca44567a367d9d7f74 \
+    --hash=sha256:a766c1dccb30c5f6eb2b203f87edd1d8588847709c78589e1521d769addc8218 \
+    # via pygithub
 docutils==0.15.2 \
     --hash=sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0 \
     --hash=sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827 \
@@ -155,9 +159,9 @@ idna==2.9 \
     --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb \
     --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
     # via -r requirements.in, requests
-importlib-metadata==1.7.0 \
-    --hash=sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83 \
-    --hash=sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070 \
+importlib-metadata==1.6.1 \
+    --hash=sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545 \
+    --hash=sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958 \
     # via flake8, pluggy, pytest
 incremental==17.5.0 \
     --hash=sha256:717e12246dddf231a349175f48d74d93e2897244939173b01974ab6661406b9f \
@@ -354,6 +358,14 @@ pyflakes==2.2.0 \
     --hash=sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92 \
     --hash=sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8 \
     # via -r requirements.in, flake8
+pygithub==1.51 \
+    --hash=sha256:8375a058ec651cc0774244a3bc7395cf93617298735934cdd59e5bcd9a1df96e \
+    --hash=sha256:d2d17d1e3f4474e070353f201164685a95b5a92f5ee0897442504e399c7bc249 \
+    # via -r requirements.in
+pyjwt==1.7.1 \
+    --hash=sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e \
+    --hash=sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96 \
+    # via pygithub
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
@@ -407,7 +419,7 @@ regex==2020.6.8 \
 requests==2.24.0 \
     --hash=sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b \
     --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898 \
-    # via -r requirements.in, google-api-core, smart-open
+    # via -r requirements.in, google-api-core, pygithub
 rsa==4.6 \
     --hash=sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa \
     --hash=sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233 \
@@ -486,6 +498,9 @@ wcwidth==0.2.4 \
     --hash=sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f \
     --hash=sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f \
     # via -r requirements.in, pytest
+wrapt==1.12.1 \
+    --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7 \
+    # via deprecated
 zipp==3.1.0 \
     --hash=sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b \
     --hash=sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96 \

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "jinja2",
         "mozanalysis",
         "pyarrow",
+        "PyGithub",
         "pytz",
         "requests",
         "smart_open",


### PR DESCRIPTION
This adds support to pull in configs from [pensieve-config](https://github.com/mozilla/pensieve-config/)

I already set up pensieve-config to trigger pensieve when a PR gets merged. It will trigger a cloud function which spins up a GCE instance running pensieve.  I should probably put the script for this somewhere...

As follow-ups to this PR we should look into a way to shutdown GCE instances when they are done with running pensieve and in cases of errors, notifying users. Right now there is no indicator when things go wrong or are done, data just appears in the tables.