### PR TITLE
Don't run overall analysis until the experiment's complete

### DIFF
--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -86,14 +86,15 @@ class Analysis:
 
             return current_time_limits
 
-        # Period is OVERALL
-        # The last full day of data for an experiment is the day before an operator switches it off.
-        tomorrow = current_date + timedelta(days=1)
-        if self.config.experiment.end_date != tomorrow:
+        assert period == AnalysisPeriod.OVERALL
+        if (
+            self.config.experiment.end_date != current_date
+            or self.config.experiment.status != "Complete"
+        ):
             return None
 
         return TimeLimits.for_single_analysis_window(
-            last_date_full_data=current_date_str,
+            last_date_full_data=prior_date_str,
             analysis_start_days=0,
             analysis_length_dates=(
                 self.config.experiment.end_date - self.config.experiment.start_date

--- a/pensieve/tests/conftest.py
+++ b/pensieve/tests/conftest.py
@@ -35,4 +35,14 @@ def experiments():
             variants=[],
             normandy_slug=None,
         ),
+        Experiment(
+            slug="test_slug",
+            type="pref",
+            status="Live",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            variants=[],
+            normandy_slug="normandy-test-slug",
+        ),
     ]

--- a/pensieve/tests/test_analysis.py
+++ b/pensieve/tests/test_analysis.py
@@ -10,7 +10,11 @@ from pensieve.experimenter import Experiment
 
 def test_get_timelimits_if_ready(experiments):
     config = AnalysisSpec().resolve(experiments[0])
+    config2 = AnalysisSpec().resolve(experiments[2])
+
     analysis = Analysis("test", "test", config)
+    analysis2 = Analysis("test", "test", config2)
+
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(0)
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date) is None
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date) is None
@@ -28,10 +32,11 @@ def test_get_timelimits_if_ready(experiments):
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date)
 
     date = dt.datetime(2020, 2, 29, tzinfo=pytz.utc)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date)
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date) is None
 
     date = dt.datetime(2020, 3, 1, tzinfo=pytz.utc)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date)
+    assert analysis2._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date) is None
 
 
 def test_regression_20200320():


### PR DESCRIPTION
The experiment's end_date is the proposed end_date until the experiment actually ends. Then, end_date is updated to the date the experiment ended. The day before the experiment ends is the last date of complete data.

Fixes #99.