### PR TITLE
Allow statistics tables to represent comparisons between treatment branches

### DIFF
--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -17,6 +17,7 @@ from mozanalysis.utils import add_days
 
 from . import AnalysisPeriod
 from pensieve.config import AnalysisConfiguration
+from pensieve.statistics import StatisticResult
 
 
 @attr.s(auto_attribs=True)
@@ -187,17 +188,7 @@ class Analysis:
             results += m.run(metrics_data).to_dict()["data"]
 
         job_config = bigquery.LoadJobConfig()
-        job_config.schema = [
-            bigquery.SchemaField("metric", "STRING"),
-            bigquery.SchemaField("statistic", "STRING"),
-            bigquery.SchemaField("parameter", "NUMERIC"),
-            bigquery.SchemaField("branch", "STRING"),
-            bigquery.SchemaField("comparison_to_control", "STRING"),
-            bigquery.SchemaField("ci_width", "FLOAT64"),
-            bigquery.SchemaField("point", "FLOAT64"),
-            bigquery.SchemaField("lower", "FLOAT64"),
-            bigquery.SchemaField("upper", "FLOAT64"),
-        ]
+        job_config.schema = StatisticResult.bq_schema
         job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
 
         # wait for the job to complete

--- a/pensieve/tests/test_statistics.py
+++ b/pensieve/tests/test_statistics.py
@@ -11,7 +11,7 @@ class TestStatistics:
         )
         result = stat.transform(test_data, "value")
 
-        branch_results = [r for r in result.data if r.comparison_to_control is None]
+        branch_results = [r for r in result.data if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
         control_result = [r for r in branch_results if r.branch == "control"][0]
         assert treatment_result.point < control_result.point
@@ -26,12 +26,12 @@ class TestStatistics:
             }
         )
         result = stat.transform(test_data, "value")
-        branch_results = [r for r in result.data if r.comparison_to_control is None]
+        branch_results = [r for r in result.data if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
         control_result = [r for r in branch_results if r.branch == "control"][0]
         assert treatment_result.point < control_result.point
         assert treatment_result.point - 0.7 < 1e-5
 
-        difference = [r for r in result.data if r.comparison_to_control == "difference"][0]
+        difference = [r for r in result.data if r.comparison == "difference"][0]
         assert difference.point - 0.2 < 1e-5
         assert difference.lower and difference.upper


### PR DESCRIPTION
`comparison` records the comparison being made; `comparison_to_branch` 
records to which branch the comparison is relative.

Moves the BigQuery schema for statistics onto the StatisticResult object 
to make it easier to keep them in sync.

@emtwo, can you ptal? This is a backwards-incompatible schema change for the statistics tables.

Closes #105.