### PR TITLE
Add a count statistic

### DIFF
--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -17,7 +17,7 @@ from mozanalysis.utils import add_days
 
 from . import AnalysisPeriod
 from pensieve.config import AnalysisConfiguration
-from pensieve.statistics import StatisticResult
+from pensieve.statistics import Count, StatisticResult
 
 
 @attr.s(auto_attribs=True)
@@ -186,6 +186,8 @@ class Analysis:
 
         for m in self.config.metrics[period]:
             results += m.run(metrics_data).to_dict()["data"]
+
+        results += Count().transform(metrics_data, "*").to_dict()["data"]
 
         job_config = bigquery.LoadJobConfig()
         job_config.schema = StatisticResult.bq_schema

--- a/pensieve/statistics.py
+++ b/pensieve/statistics.py
@@ -337,3 +337,28 @@ class Deciles(Statistic):
                 )
 
         return stats_results
+
+
+class Count(Statistic):
+    def apply(self, df: DataFrame, metric: str):
+        return self.transform(df, metric)
+
+    def transform(self, df: DataFrame, metric: str) -> StatisticResultCollection:
+        results = []
+        counts = df.groupby("branch").size()
+        for branch, n in counts.items():
+            results.append(
+                StatisticResult(
+                    metric="identity",
+                    statistic="count",
+                    parameter=None,
+                    branch=branch,
+                    comparison=None,
+                    comparison_to_branch=None,
+                    ci_width=None,
+                    point=n,
+                    lower=None,
+                    upper=None,
+                )
+            )
+        return StatisticResultCollection(results)

--- a/pensieve/tests/integration/test_analysis_integration.py
+++ b/pensieve/tests/integration/test_analysis_integration.py
@@ -168,6 +168,15 @@ class TestAnalysisIntegration:
             )
             is not None
         )
+
+        stats = client.list_rows(
+            f"{self.project_id}.{self.test_dataset}.statistics_test_experiment_week_1"
+        ).to_dataframe()
+
+        count_by_branch = stats.query("statistic == 'count'").set_index("branch")
+        assert count_by_branch.loc["branch1", "point"] == 1.0
+        assert count_by_branch.loc["branch2", "point"] == 1.0
+
         assert (
             client.get_table(
                 f"{self.project_id}.{self.test_dataset}.statistics_test_experiment_weekly"

--- a/pensieve/tests/test_statistics.py
+++ b/pensieve/tests/test_statistics.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from pensieve.statistics import BootstrapMean, Binomial
+from pensieve.statistics import BootstrapMean, Binomial, Count
 
 
 class TestStatistics:
@@ -35,3 +35,12 @@ class TestStatistics:
         difference = [r for r in result.data if r.comparison == "difference"][0]
         assert difference.point - 0.2 < 1e-5
         assert difference.lower and difference.upper
+
+    def test_count(self):
+        stat = Count()
+        test_data = pd.DataFrame(
+            {"branch": ["treatment"] * 20 + ["control"] * 10, "value": list(range(30))}
+        )
+        result = stat.transform(test_data, "asdfasdf").data
+        assert [r.point for r in result if r.branch == "treatment"] == [20]
+        assert [r.point for r in result if r.branch == "control"] == [10]


### PR DESCRIPTION
Add a special statistic that counts the number of clients enrolled in each branch. It doesn't depend on the value of any of the metrics columns -- just the number of rows for each branch, since each metrics table will have one row per client per branch.

It's awkward to express in configuration since it doesn't have a corresponding metric and it seems in poor form to invent one.

It should be the same for all statistics tables for an experiment (but may not be, because of Shredder).