### PR TITLE
Add CLI command for validating config files

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -219,13 +219,13 @@ def validate_config(ctx, path):
         # check if there is an experiment with a matching slug in Experimenter
         slug = os.path.splitext(os.path.basename(file))[0]
         if collection.with_slug(slug).experiments == []:
-            click.echo(f"No experiment with slug {slug} in Experimenter.", err=False)
+            click.echo(f"No experiment with slug {slug} in Experimenter.", err=True)
+            sys.exit(1)
         else:
             # dry run experiment analysis with the config file
             # this will make sure config file contents are valid
             ctx.invoke(
-                run,
-                date=config.experiment.start_date,
+                rerun,
                 experiment_slug=slug,
                 dry_run=True,
                 config_file=file,

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -200,6 +200,8 @@ def validate_config(path):
     """Validate config files."""
     config_files = [p for p in path if os.path.isfile(p)]
 
+    collection = ExperimentCollection.from_experimenter()
+
     # required to resolve the config
     dummy_experiment = Experiment(
         slug="config_dummy",
@@ -213,7 +215,13 @@ def validate_config(path):
 
     for file in config_files:
         click.echo(f"Validate {file}", err=False)
+
         spec = AnalysisSpec.from_dict(toml.load(file))
         spec.resolve(dummy_experiment)
+
+        # check if there is an experiment with a matching slug in Experimenter
+        slug = os.path.splitext(os.path.basename(file))[0]
+        if collection.with_slug(slug).experiments == []:
+            click.echo(f"No experiment with slug {slug} in Experimenter.", err=False)
 
         click.echo(f"Config file at {file} is valid.", err=False)

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -10,9 +10,8 @@ import sys
 import toml
 
 from . import experimenter
-from .experimenter import Experiment
 from .config import AnalysisSpec
-from .experimenter import ExperimentCollection
+from .experimenter import Experiment, ExperimentCollection
 from .export_json import export_statistics_tables
 from .analysis import Analysis
 from .external_config import ExternalConfigCollection
@@ -196,20 +195,10 @@ def rerun_config_changed(project_id, dataset_id):
 
 
 @cli.command("validate_config")
-@click.argument("path")
+@click.argument("path", type=click.Path(exists=True), nargs=-1)
 def validate_config(path):
     """Validate config files."""
-    config_files = []
-    if os.path.isdir(path):
-        config_files = [
-            os.path.join(path, f)
-            for f in os.listdir(path)
-            if os.path.isfile(os.path.join(path, f)) and f.endswith(".toml")
-        ]
-    elif os.path.isfile(path):
-        config_files = [path]
-    else:
-        logging.error(f"Invalid path to config file: {path}")
+    config_files = [p for p in path if os.path.isfile(p)]
 
     # required to resolve the config
     dummy_experiment = Experiment(
@@ -223,8 +212,8 @@ def validate_config(path):
     )
 
     for file in config_files:
-        logging.info(f"Validate {file}")
+        click.echo(f"Validate {file}", err=False)
         spec = AnalysisSpec.from_dict(toml.load(file))
         spec.resolve(dummy_experiment)
 
-        print(f"Config file at {file} is valid.")
+        click.echo(f"Config file at {file} is valid.", err=False)

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -214,7 +214,7 @@ def validate_config(ctx, path):
         click.echo(f"Validate {file}", err=False)
 
         spec = AnalysisSpec.from_dict(toml.load(file))
-        config = spec.resolve(dummy_experiment)
+        spec.resolve(dummy_experiment)
 
         # check if there is an experiment with a matching slug in Experimenter
         slug = os.path.splitext(os.path.basename(file))[0]
@@ -225,10 +225,7 @@ def validate_config(ctx, path):
             # dry run experiment analysis with the config file
             # this will make sure config file contents are valid
             ctx.invoke(
-                rerun,
-                experiment_slug=slug,
-                dry_run=True,
-                config_file=file,
+                rerun, experiment_slug=slug, dry_run=True, config_file=file,
             )
 
         click.echo(f"Config file at {file} is valid.", err=False)


### PR DESCRIPTION
This can be used in https://github.com/mozilla/jetstream-config/blob/1dbf20fb8860b9051fe0e57c2aa31550f3dff912/.circleci/config.yml#L9 to validate config files added to the [jetstream-config](https://github.com/mozilla/jetstream-config) repository.

See https://github.com/mozilla/jetstream/issues/107