### PR TITLE
Allow users to override control branch slug

### DIFF
--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pytest
 import pytz
 
-from jetstream.experimenter import Experiment
+from jetstream.experimenter import Experiment, Variant
 
 
 def pytest_addoption(parser):
@@ -22,7 +22,10 @@ def experiments():
             start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
             end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
             proposed_enrollment=7,
-            variants=[],
+            variants=[
+                Variant(slug="a", is_control=False, ratio=1),
+                Variant(slug="b", is_control=True, ratio=1),
+            ],
             normandy_slug="normandy-test-slug",
         ),
         Experiment(

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -378,3 +378,17 @@ class TestExperimentSpec:
         spec = config.AnalysisSpec.from_dict(toml.loads(conf))
         with pytest.raises(ValueError):
             spec.resolve(experiments[0])
+
+    def test_control_branch(self, experiments):
+        trivial = config.AnalysisSpec().resolve(experiments[0])
+        assert trivial.experiment.control_branch == "b"
+
+        conf = dedent(
+            """
+            [experiment]
+            control_branch = "a"
+            """
+        )
+        spec = config.AnalysisSpec.from_dict(toml.loads(conf))
+        configured = spec.resolve(experiments[0])
+        assert configured.experiment.control_branch == "a"


### PR DESCRIPTION
Specifying experiment.control_branch in the configuration file will override data in Experimenter. This is a workaround for #130; we'll need something like this as part of enabling all-pairwise-comparisons anyway.