### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99


### PR DESCRIPTION
See https://github.com/mozilla/jetstream/issues/152

Might be useful to have to keep track of updates and security vulnerabilities. 