### PR TITLE
Validate all metrics

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -180,7 +180,11 @@ class Analysis:
         )
 
         if dry_run:
-            dry_run_query(sql)
+            self.logger.info(
+                "Dry run; not actually calculating %s metrics for %s",
+                period.value,
+                self.config.experiment.normandy_slug,
+            )
         else:
             self.logger.info(
                 "Executing query for %s (%s)",

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -276,11 +276,16 @@ class Analysis:
 
         dates_enrollment = self.config.experiment.proposed_enrollment + 1
 
-        analysis_length_dates = (
-            (self.config.experiment.end_date - self.config.experiment.start_date).days
-            - dates_enrollment
-            + 1
-        )
+        if self.config.experiment.end_date is not None:
+            end_date = self.config.experiment.end_date
+            analysis_length_dates = (
+                (end_date - self.config.experiment.start_date).days - dates_enrollment + 1
+            )
+        else:
+            analysis_length_dates = 21  # arbitrary
+            end_date = self.config.experiment.start_date + timedelta(
+                days=analysis_length_dates + dates_enrollment - 1
+            )
 
         if analysis_length_dates < 0:
             logging.error(
@@ -290,7 +295,7 @@ class Analysis:
             raise Exception("Cannot validate experiment")
 
         limits = TimeLimits.for_single_analysis_window(
-            last_date_full_data=self.config.experiment.end_date.strftime("%Y-%m-%d"),
+            last_date_full_data=end_date.strftime("%Y-%m-%d"),
             analysis_start_days=0,
             analysis_length_dates=analysis_length_dates,
             first_enrollment_date=self.config.experiment.start_date.strftime("%Y-%m-%d"),

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -61,9 +61,6 @@ project_id_option = click.option(
 dataset_id_option = click.option(
     "--dataset_id", "--dataset-id", default="mozanalysis", help="Dataset to write to"
 )
-dry_run_option = click.option(
-    "--dry_run/--no_dry_run", help="Don't publish any changes to BigQuery"
-)
 
 experiment_slug_option = click.option(
     "--experiment_slug",
@@ -89,9 +86,8 @@ bucket_option = click.option("--bucket", default="mozanalysis", help="GCS bucket
     required=True,
 )
 @experiment_slug_option
-@dry_run_option
 @secret_config_file_option
-def run(project_id, dataset_id, date, experiment_slug, dry_run, config_file):
+def run(project_id, dataset_id, date, experiment_slug, config_file):
     """Fetches experiments from Experimenter and runs analysis on active experiments."""
     # fetch experiments that are still active
     collection = ExperimentCollection.from_experimenter()
@@ -124,16 +120,15 @@ def run(project_id, dataset_id, date, experiment_slug, dry_run, config_file):
                 spec.merge(external_experiment_config)
 
         config = spec.resolve(experiment)
-        Analysis(project_id, dataset_id, config).run(date, dry_run=dry_run)
+        Analysis(project_id, dataset_id, config).run(date)
 
 
 @cli.command("rerun")
 @experiment_slug_option
 @project_id_option
 @dataset_id_option
-@dry_run_option
 @secret_config_file_option
-def rerun(project_id, dataset_id, experiment_slug, dry_run, config_file):
+def rerun(project_id, dataset_id, experiment_slug, config_file):
     """Rerun all available analyses for a specific experiment."""
     collection = ExperimentCollection.from_experimenter()
 
@@ -173,7 +168,7 @@ def rerun(project_id, dataset_id, experiment_slug, dry_run, config_file):
 
     for date in inclusive_date_range(experiment.start_date, end_date):
         logging.info(f"*** {date}")
-        Analysis(project_id, dataset_id, config).run(date, dry_run=dry_run)
+        Analysis(project_id, dataset_id, config).run(date)
 
 
 @cli.command()
@@ -196,7 +191,7 @@ def rerun_config_changed(ctx, project_id, dataset_id):
 
     updated_external_configs = external_configs.updated_configs(project_id, dataset_id)
     for external_config in updated_external_configs:
-        ctx.invoke(rerun, project_id, dataset_id, external_config.normandy_slug, dry_run=False)
+        ctx.invoke(rerun, project_id, dataset_id, external_config.normandy_slug)
 
 
 @cli.command("validate_config")

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -2,8 +2,11 @@ import datetime as dt
 from datetime import timedelta
 import json
 import pytz
+from unittest.mock import Mock
 
+import jetstream.analysis
 from jetstream.analysis import Analysis, AnalysisPeriod
+from jetstream.cli import default_spec_for_experiment
 from jetstream.config import AnalysisSpec
 from jetstream.experimenter import ExperimentV1
 
@@ -134,3 +137,12 @@ def test_regression_20200316():
     config = AnalysisSpec().resolve(experiment)
     analysis = Analysis("test", "test", config)
     analysis.run(current_date=dt.datetime(2020, 3, 16, tzinfo=pytz.utc), dry_run=True)
+
+
+def test_validate_doesnt_explode(experiments, monkeypatch):
+    m = Mock()
+    monkeypatch.setattr(jetstream.analysis, "dry_run_query", m)
+    x = experiments[0]
+    config = default_spec_for_experiment(x).resolve(x)
+    Analysis("spam", "eggs", config).validate()
+    m.assert_called_once()


### PR DESCRIPTION
Fixes #210, probably moots #129. 

Writes a single query for the overall experiment in order to check the edges of the windows and all of the metrics.

This probably needs some tests; we might need to remove most of the existing dry_run options in the Analysis class since we're no longer using them.

Ironically it's a little WET but I don't think the copypasta is too bad unless you see an obvious refactoring opportunity.