### PR TITLE
Allow segment definitions

### DIFF
--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -515,8 +515,8 @@ class SegmentsSpec:
 
     def merge(self, other: "SegmentsSpec"):
         """
-        Merge another datasource spec into the current one.
-        The `other` DataSourcesSpec overwrites existing keys.
+        Merge another segments spec into the current one.
+        The `other` SegmentsSpec overwrites existing keys.
         """
         self.data_sources.update(other.data_sources)
         self.definitions.update(other.definitions)

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Mapping, Optional, Type, TYPE_CHECKING, Type
 import attr
 import cattr
 import jinja2
+from jinja2 import StrictUndefined
 import mozanalysis.metrics
 import mozanalysis.metrics.desktop
 import mozanalysis.segments
@@ -46,7 +47,7 @@ def _populate_environment() -> jinja2.Environment:
     """Create a Jinja2 environment that understands the SQL agg_* helpers in mozanalysis.metrics.
 
     Just a wrapper to avoid leaking temporary variables to the module scope."""
-    env = jinja2.Environment(autoescape=False)
+    env = jinja2.Environment(autoescape=False, undefined=StrictUndefined)
     for name in dir(mozanalysis.metrics):
         if not name.startswith("agg_"):
             continue
@@ -187,7 +188,7 @@ class ExperimentConfiguration:
             def __getattr__(proxy, name):
                 return getattr(self, name)
 
-        env = jinja2.Environment(autoescape=False)
+        env = jinja2.Environment(autoescape=False, undefined=StrictUndefined)
         return env.from_string(self.experiment_spec.enrollment_query).render(
             experiment=ExperimentProxy()
         )
@@ -478,7 +479,7 @@ class SegmentDataSourceDefinition:
     def resolve(
         self, spec: "AnalysisSpec", experiment: ExperimentConfiguration
     ) -> mozanalysis.segments.SegmentDataSource:
-        env = jinja2.Environment(autoescape=False)
+        env = jinja2.Environment(autoescape=False, undefined=StrictUndefined)
         from_expr = env.from_string(self.from_expression).render(experiment=experiment)
         kwargs = {
             "name": self.name,

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -224,6 +224,19 @@ class ExperimentConfiguration:
         """
         return "Complete" if self.experiment_spec.end_date else self.experimenter_experiment.status
 
+    # Helpers for configuration templates
+    @property
+    def start_date_str(self) -> str:
+        if not self.start_date:
+            return "1970-01-01"
+        return self.start_date.strftime("%Y-%m-%d")
+
+    @property
+    def last_enrollment_date_str(self) -> str:
+        if not self.start_date:
+            return "1970-01-01"
+        return (self.start_date + dt.timedelta(days=self.proposed_enrollment)).strftime("%Y-%m-%d")
+
     def __getattr__(self, name: str) -> Any:
         return getattr(self.experimenter_experiment, name)
 

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -34,6 +34,7 @@ import mozanalysis.segments.desktop
 import pytz
 
 from . import AnalysisPeriod, nimbus
+from jetstream.errors import NoStartDateException
 from jetstream.statistics import Summary, Statistic
 from jetstream.pre_treatment import PreTreatment
 
@@ -229,13 +230,13 @@ class ExperimentConfiguration:
     @property
     def start_date_str(self) -> str:
         if not self.start_date:
-            return "1970-01-01"
+            raise NoStartDateException(self.normandy_slug)
         return self.start_date.strftime("%Y-%m-%d")
 
     @property
     def last_enrollment_date_str(self) -> str:
         if not self.start_date:
-            return "1970-01-01"
+            raise NoStartDateException(self.normandy_slug)
         return (self.start_date + dt.timedelta(days=self.proposed_enrollment)).strftime("%Y-%m-%d")
 
     def __getattr__(self, name: str) -> Any:

--- a/jetstream/errors.py
+++ b/jetstream/errors.py
@@ -1,0 +1,23 @@
+class NoSlugException(Exception):
+    def __init__(self, message="Experiment has no slug"):
+        super().__init__(message)
+
+
+class NoEnrollmentPeriodException(Exception):
+    def __init__(self, normandy_slug, message="Experiment has no enrollment period"):
+        super().__init__(f"{normandy_slug} -> {message}")
+
+
+class NoStartDateException(Exception):
+    def __init__(self, normandy_slug, message="Experiment has no start date."):
+        super().__init__(f"{normandy_slug} -> {message}")
+
+
+class EndedException(Exception):
+    def __init__(self, normandy_slug, message="Experiment has already ended."):
+        super().__init__(f"{normandy_slug} -> {message}")
+
+
+class EnrollmentLongerThanAnalysisException(Exception):
+    def __init__(self, normandy_slug, message="Enrollment period is longer than analysis dates."):
+        super().__init__(f"{normandy_slug} -> {message}")

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -10,7 +10,8 @@ import pytz
 import toml
 
 import jetstream.analysis
-from jetstream.analysis import Analysis, AnalysisPeriod, NoEnrollmentPeriodException
+from jetstream.analysis import Analysis, AnalysisPeriod
+from jetstream.errors import NoEnrollmentPeriodException
 from jetstream.cli import default_spec_for_experiment
 from jetstream.config import AnalysisSpec
 from jetstream.experimenter import ExperimentV1

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -440,8 +440,8 @@ class TestExperimentSpec:
             select_expression = "{{agg_any('1')}}"
 
             [segments.data_sources.my_cool_data_source]
-            from_expression = "(SELECT 1)"
-            """
+            from_expression = "(SELECT 1 WHERE submission_date BETWEEN {{experiment.start_date_str}} AND {{experiment.last_enrollment_date_str}})"
+            """  # noqa
         )
 
         spec = config.AnalysisSpec.from_dict(toml.loads(conf))
@@ -452,6 +452,9 @@ class TestExperimentSpec:
         assert configured.experiment.segments[0].name == "regular_users_v3"
         assert configured.experiment.segments[1].name == "my_cool_segment"
         assert "agg_any" not in configured.experiment.segments[1].select_expr
+        assert "1970" not in configured.experiment.segments[1].data_source.from_expr
+        assert "{{" not in configured.experiment.segments[1].data_source.from_expr
+        assert "2019-12-01" in configured.experiment.segments[1].data_source.from_expr
 
 
 class TestExperimentConf:

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -429,6 +429,30 @@ class TestExperimentSpec:
         configured = spec.resolve(experiments[0])
         assert isinstance(configured.experiment.segments[0], mozanalysis.segments.Segment)
 
+    def test_segment_definitions(self, experiments):
+        conf = dedent(
+            """
+            [experiment]
+            segments = ["regular_users_v3", "my_cool_segment"]
+
+            [segments.my_cool_segment]
+            data_source = "my_cool_data_source"
+            select_expression = "{{agg_any('1')}}"
+
+            [segments.data_sources.my_cool_data_source]
+            from_expression = "(SELECT 1)"
+            """
+        )
+
+        spec = config.AnalysisSpec.from_dict(toml.loads(conf))
+        configured = spec.resolve(experiments[0])
+        assert len(configured.experiment.segments) == 2
+        for segment in configured.experiment.segments:
+            assert isinstance(segment, mozanalysis.segments.Segment)
+        assert configured.experiment.segments[0].name == "regular_users_v3"
+        assert configured.experiment.segments[1].name == "my_cool_segment"
+        assert "agg_any" not in configured.experiment.segments[1].select_expr
+
 
 class TestExperimentConf:
     def test_bad_end_date(self, experiments):


### PR DESCRIPTION
Part of #58.

Lets you write configurations like:

```toml
[experiment]
segments = ["regular_users_v3", "my_cool_segment"]

[segments.my_cool_segment]
data_source = "my_cool_data_source"
select_expression = "{{agg_any('1')}}"

[segments.data_sources.my_cool_data_source]
from_expression = "(SELECT 1)"
```

Resolved segments end up in the list `ExperimentConfiguration.segments`.