### PR TITLE
Normalize slugs to table names

### DIFF
--- a/jetstream/__init__.py
+++ b/jetstream/__init__.py
@@ -1,4 +1,5 @@
 import enum
+import re
 
 
 class AnalysisPeriod(enum.Enum):
@@ -10,3 +11,7 @@ class AnalysisPeriod(enum.Enum):
     def adjective(self) -> str:
         d = {"day": "daily", "week": "weekly", "overall": "overall"}
         return d[self.value]
+
+
+def bq_normalize_name(name: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_]", "_", name)

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import re
 import logging
 from textwrap import dedent
 import time
@@ -16,7 +15,7 @@ import mozanalysis
 from mozanalysis.experiment import TimeLimits
 from mozanalysis.utils import add_days
 
-from . import AnalysisPeriod
+from . import AnalysisPeriod, bq_normalize_name
 from jetstream.config import AnalysisConfiguration
 from jetstream.dryrun import dry_run_query
 import jetstream.errors as errors
@@ -112,12 +111,9 @@ class Analysis:
             **time_limits_args,
         )
 
-    def _normalize_name(self, name: str) -> str:
-        return re.sub(r"[^a-zA-Z0-9_]", "_", name)
-
     def _table_name(self, window_period: str, window_index: int) -> str:
         assert self.config.experiment.normandy_slug is not None
-        normalized_slug = self._normalize_name(self.config.experiment.normandy_slug)
+        normalized_slug = bq_normalize_name(self.config.experiment.normandy_slug)
         return "_".join([normalized_slug, window_period, str(window_index)])
 
     def _publish_view(self, window_period: AnalysisPeriod, table_prefix=None):

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -118,12 +118,12 @@ class Analysis:
 
     def _publish_view(self, window_period: AnalysisPeriod, table_prefix=None):
         assert self.config.experiment.normandy_slug is not None
-        normalized_slug = self._normalize_name(self.config.experiment.normandy_slug)
+        normalized_slug = bq_normalize_name(self.config.experiment.normandy_slug)
         view_name = "_".join([normalized_slug, window_period.adjective])
         wildcard_expr = "_".join([normalized_slug, window_period.value, "*"])
 
         if table_prefix:
-            normalized_prefix = self._normalize_name(table_prefix)
+            normalized_prefix = bq_normalize_name(table_prefix)
             view_name = "_".join([normalized_prefix, view_name])
             wildcard_expr = "_".join([normalized_prefix, wildcard_expr])
 

--- a/jetstream/external_config.py
+++ b/jetstream/external_config.py
@@ -15,6 +15,7 @@ import pytz
 import toml
 from typing import List, Optional
 
+from . import bq_normalize_name
 from jetstream.config import AnalysisSpec
 
 
@@ -95,7 +96,7 @@ class ExternalConfigCollection:
         for config in self.configs:
             for row in result:
                 if (
-                    row.table_name.startswith(config.slug)
+                    row.table_name.startswith(bq_normalize_name(config.slug))
                     and len(row.last_updated) > 0
                     and pytz.UTC.localize(dt.datetime.fromtimestamp(int(row.last_updated[0])))
                     < config.last_modified


### PR DESCRIPTION
ExternalConfig.updated_configs() would return an empty list because it was looking for tables that could never exist; dashes are common in Normandy slugs and they need to be normalized to underscores.