### PR TITLE
Delete tables on re-run that have been previously created for experiment

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1,16 +1,10 @@
 from datetime import datetime, timedelta
 import logging
 from textwrap import dedent
-import time
 from typing import Optional
 
 import attr
-import google.cloud.bigquery.client
-import google.cloud.bigquery.dataset
-import google.cloud.bigquery.job
-import google.cloud.bigquery.table
 from google.cloud import bigquery
-from google.cloud.bigquery_storage_v1beta1 import BigQueryStorageClient
 import mozanalysis
 from mozanalysis.experiment import TimeLimits
 from mozanalysis.utils import add_days
@@ -20,6 +14,7 @@ from jetstream.config import AnalysisConfiguration
 from jetstream.dryrun import dry_run_query
 import jetstream.errors as errors
 from jetstream.statistics import Count, StatisticResult, StatisticResultCollection
+from jetstream.bigquery_client import BigQueryClient
 
 logger = logging.getLogger(__name__)
 
@@ -364,69 +359,4 @@ class Analysis:
                 "Finished running query for %s (%s)",
                 self.config.experiment.normandy_slug,
                 period.value,
-            )
-
-
-@attr.s(auto_attribs=True, slots=True)
-class BigQueryClient:
-    project: str
-    dataset: str
-    _client: Optional[google.cloud.bigquery.client.Client] = None
-    _storage_client: Optional[BigQueryStorageClient] = None
-
-    @property
-    def client(self):
-        self._client = self._client or google.cloud.bigquery.client.Client(self.project)
-        return self._client
-
-    def table_to_dataframe(self, table: str):
-        """Return all rows of the specified table as a dataframe."""
-        self._storage_client = self._storage_client or BigQueryStorageClient()
-
-        table_ref = self.client.get_table(f"{self.project}.{self.dataset}.{table}")
-        rows = self.client.list_rows(table_ref)
-        return rows.to_dataframe(bqstorage_client=self._storage_client)
-
-    def add_labels_to_table(self, table, labels):
-        """Adds the provided labels to the table."""
-        table_ref = self.client.dataset(self.dataset).table(table)
-        table = self.client.get_table(table_ref)
-        table.labels = labels
-
-        self.client.update_table(table, ["labels"])
-
-    def _current_timestamp_label(self):
-        """Returns the current UTC timestamp as a valid BigQuery label."""
-        return str(int(time.mktime(datetime.utcnow().timetuple())))
-
-    def load_table_from_json(self, results, table, job_config):
-        # wait for the job to complete
-        destination_table = f"{self.project}.{self.dataset}.{table}"
-        self.client.load_table_from_json(results, destination_table, job_config=job_config).result()
-
-        # add a label with the current timestamp to the table
-        self.add_labels_to_table(
-            table,
-            {"last_updated": self._current_timestamp_label()},
-        )
-
-    def execute(self, query: str, destination_table: Optional[str] = None) -> None:
-        dataset = google.cloud.bigquery.dataset.DatasetReference.from_string(
-            self.dataset,
-            default_project=self.project,
-        )
-        kwargs = {}
-        if destination_table:
-            kwargs["destination"] = dataset.table(destination_table)
-            kwargs["write_disposition"] = google.cloud.bigquery.job.WriteDisposition.WRITE_TRUNCATE
-        config = google.cloud.bigquery.job.QueryJobConfig(default_dataset=dataset, **kwargs)
-        job = self.client.query(query, config)
-        # block on result
-        job.result(max_results=1)
-
-        if destination_table:
-            # add a label with the current timestamp to the table
-            self.add_labels_to_table(
-                destination_table,
-                {"last_updated": self._current_timestamp_label()},
             )

--- a/jetstream/bigquery_client.py
+++ b/jetstream/bigquery_client.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+import re
+import time
+from typing import Optional
+
+import attr
+import google.cloud.bigquery.client
+import google.cloud.bigquery.dataset
+import google.cloud.bigquery.job
+import google.cloud.bigquery.table
+from google.cloud.bigquery_storage_v1beta1 import BigQueryStorageClient
+
+
+@attr.s(auto_attribs=True, slots=True)
+class BigQueryClient:
+    project: str
+    dataset: str
+    _client: Optional[google.cloud.bigquery.client.Client] = None
+    _storage_client: Optional[BigQueryStorageClient] = None
+
+    @property
+    def client(self):
+        self._client = self._client or google.cloud.bigquery.client.Client(self.project)
+        return self._client
+
+    def table_to_dataframe(self, table: str):
+        """Return all rows of the specified table as a dataframe."""
+        self._storage_client = self._storage_client or BigQueryStorageClient()
+
+        table_ref = self.client.get_table(f"{self.project}.{self.dataset}.{table}")
+        rows = self.client.list_rows(table_ref)
+        return rows.to_dataframe(bqstorage_client=self._storage_client)
+
+    def add_labels_to_table(self, table, labels):
+        """Adds the provided labels to the table."""
+        table_ref = self.client.dataset(self.dataset).table(table)
+        table = self.client.get_table(table_ref)
+        table.labels = labels
+
+        self.client.update_table(table, ["labels"])
+
+    def _current_timestamp_label(self):
+        """Returns the current UTC timestamp as a valid BigQuery label."""
+        return str(int(time.mktime(datetime.utcnow().timetuple())))
+
+    def load_table_from_json(self, results, table, job_config):
+        # wait for the job to complete
+        destination_table = f"{self.project}.{self.dataset}.{table}"
+        self.client.load_table_from_json(results, destination_table, job_config=job_config).result()
+
+        # add a label with the current timestamp to the table
+        self.add_labels_to_table(
+            table,
+            {"last_updated": self._current_timestamp_label()},
+        )
+
+    def execute(self, query: str, destination_table: Optional[str] = None) -> None:
+        dataset = google.cloud.bigquery.dataset.DatasetReference.from_string(
+            self.dataset,
+            default_project=self.project,
+        )
+        kwargs = {}
+        if destination_table:
+            kwargs["destination"] = dataset.table(destination_table)
+            kwargs["write_disposition"] = google.cloud.bigquery.job.WriteDisposition.WRITE_TRUNCATE
+        config = google.cloud.bigquery.job.QueryJobConfig(default_dataset=dataset, **kwargs)
+        job = self.client.query(query, config)
+        # block on result
+        job.result(max_results=1)
+
+        if destination_table:
+            # add a label with the current timestamp to the table
+            self.add_labels_to_table(
+                destination_table,
+                {"last_updated": self._current_timestamp_label()},
+            )
+
+    def delete_tables_matching_regex(self, regex: str):
+        """Delete all tables with names matching the specified pattern."""
+        table_name_re = re.compile(regex)
+
+        existing_tables = self.client.list_tables(self.dataset)
+        for table in existing_tables:
+            if table_name_re.match(table.table_id):
+                self.client.delete_table(table.table_id, not_found_ok=True)

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -16,7 +16,7 @@ from .analysis import Analysis
 from .external_config import ExternalConfigCollection
 from .logging.bigquery_log_handler import BigQueryLogHandler
 from .bigquery_client import BigQueryClient
-from . import bq_normalize_name
+from . import bq_normalize_name, AnalysisPeriod
 
 DEFAULT_METRICS_CONFIG = Path(__file__).parent / "config" / "default_metrics.toml"
 CFR_METRICS_CONFIG = Path(__file__).parent / "config" / "cfr_metrics.toml"
@@ -207,7 +207,8 @@ def rerun(project_id, dataset_id, experiment_slug, config_file):
         # delete all tables previously created when this experiment was analysed
         client = BigQueryClient(project_id, dataset_id)
         normalized_slug = bq_normalize_name(experiment.normandy_slug)
-        table_name_re = f"(statistics_)?{normalized_slug}.*"
+        analysis_periods = "|".join([p.value for p in AnalysisPeriod])
+        table_name_re = f"^(statistics_)?{normalized_slug}_({analysis_periods})_.*$"
         client.delete_tables_matching_regex(table_name_re)
 
         for date in inclusive_date_range(experiment.start_date, end_date):

--- a/jetstream/tests/integration/conftest.py
+++ b/jetstream/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import random
 import string
 
-from jetstream.analysis import BigQueryClient
+from jetstream.bigquery_client import BigQueryClient
 
 TEST_DIR = Path(__file__).parent.parent
 


### PR DESCRIPTION
Related to https://github.com/mozilla/jetstream/issues/235

I noticed that for the `bug-1647305-pref-comcast-steering-experiment-release-78-80` Jetstream has been triggering a complete re-run the past couple of days. The reason for this is that before there was a custom config, Jetstream had already created tables for previous analysis runs, including some for days 23 and 24. With [the new `end_date`](https://github.com/mozilla/jetstream-config/blob/0b86aaedb888cd8222cf5f51c4959e2dfb573595/bug-1647305-pref-comcast-steering-experiment-release-78-80.toml#L2) in the custom config, these two days are excluded and did not get analysed when a re-run was triggered. However, since these tables still existed and their `last_updated` timestamp was older than the custom configs creation date, Jetstream thought that the custom config got updated and triggered a re-run.

The easiest solution for this is to delete previously created tables when a re-run for a specific experiment is triggered.