### PR TITLE
Drop the highest readings by default for means

### DIFF
--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -259,6 +259,7 @@ def flatten_simple_compare_branches_result(
 @attr.s(auto_attribs=True)
 class BootstrapMean(Statistic):
     num_samples: int = 10000
+    drop_highest: float = 1e-4
     confidence_interval: float = 0.95
 
     def transform(
@@ -277,6 +278,7 @@ class BootstrapMean(Statistic):
             ref_branch_label=reference_branch,
             num_samples=self.num_samples,
             individual_summary_quantiles=summary_quantiles,
+            threshold_quantile=1 - self.drop_highest,
         )
 
         return flatten_simple_compare_branches_result(


### PR DESCRIPTION
Means are dangerous because they take outlier clients too seriously. This drops the highest ten-thousandth of values before computing means. Data scientists can override it by specifying drop_highest = 0.

Closes #222.