### PR TITLE
Run analysis steps in parallel with Dask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /app
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y git
+RUN apt-get install -y gcc
 
 COPY . .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM python:3.8-slim
+FROM python:3.8
 
 RUN mkdir -p /app
 WORKDIR /app
-
-RUN apt-get update && apt-get install -y git
-RUN apt-get install -y gcc
 
 COPY . .
 RUN pip install -r requirements.txt

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -17,6 +17,6 @@ elif [ "$1" = "run" ]; then
     jetstream --log_to_bigquery run "${@:2}"
 else
     # this is triggered by Airflow
-    jetstream --log_to_bigquery run "$@" --argo
+    jetstream --log_to_bigquery run "$@"
     jetstream --log_to_bigquery rerun-config-changed --argo
 fi

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -15,8 +15,4 @@ elif [ "$1" = "run-argo" ]; then
 elif [ "$1" = "run" ]; then
     # argo
     jetstream --log_to_bigquery run "${@:2}"
-else
-    # this is triggered by Airflow
-    jetstream --log_to_bigquery run "$@"
-    jetstream --log_to_bigquery rerun-config-changed --argo
 fi

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -21,6 +21,8 @@ from pandas import DataFrame
 
 logger = logging.getLogger(__name__)
 
+DASK_DASHBOARD_ADDRESS = "127.0.0.1:8782"
+
 
 @attr.s(auto_attribs=True)
 class Analysis:
@@ -353,7 +355,7 @@ class Analysis:
 
         # set up dask
         cluster = LocalCluster(
-            dashboard_address="127.0.0.1:8782", processes=True, threads_per_worker=1
+            dashboard_address=DASK_DASHBOARD_ADDRESS, processes=True, threads_per_worker=1
         )
         client = Client(cluster)
 

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1,23 +1,24 @@
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
 from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
 import attr
 import dask
+import mozanalysis
 from dask.distributed import Client, LocalCluster
 from google.cloud import bigquery
-import mozanalysis
 from mozanalysis.experiment import TimeLimits
 from mozanalysis.utils import add_days
+from pandas import DataFrame
 
-from . import AnalysisPeriod, bq_normalize_name
+import jetstream.errors as errors
+from jetstream.bigquery_client import BigQueryClient
 from jetstream.config import AnalysisConfiguration
 from jetstream.dryrun import dry_run_query
-import jetstream.errors as errors
 from jetstream.statistics import Count, StatisticResult, StatisticResultCollection, Summary
-from jetstream.bigquery_client import BigQueryClient
-from pandas import DataFrame
+
+from . import AnalysisPeriod, bq_normalize_name
 
 logger = logging.getLogger(__name__)
 

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -210,10 +210,10 @@ class Analysis:
             Count()
             .transform(segment_data, "*", "*", self.config.experiment.normandy_slug)
             .set_segment(segment)
-        )
+        ).to_dict()["data"]
 
         return StatisticResultCollection(
-            counts.to_dict()["data"]
+            counts
             + [
                 StatisticResult(
                     metric="identity",
@@ -229,7 +229,7 @@ class Analysis:
                     segment=segment,
                 )
                 for b in self.config.experiment.branches
-                if b.slug not in {c["branch"] for c in counts.to_dict()["data"]}
+                if b.slug not in {c["branch"] for c in counts}
             ]
         )
 

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1,20 +1,24 @@
 from datetime import datetime, timedelta
 import logging
 from textwrap import dedent
-from typing import Optional
+from typing import Optional, List, Any, Dict
 
 import attr
+import dask
+from dask.distributed import Client, LocalCluster
 from google.cloud import bigquery
 import mozanalysis
 from mozanalysis.experiment import TimeLimits
 from mozanalysis.utils import add_days
+from pandas import DataFrame
 
 from . import AnalysisPeriod, bq_normalize_name
-from jetstream.config import AnalysisConfiguration
+from jetstream.config import AnalysisConfiguration, MetricsConfigurationType
 from jetstream.dryrun import dry_run_query
 import jetstream.errors as errors
-from jetstream.statistics import Count, StatisticResult, StatisticResultCollection
+from jetstream.statistics import Count, StatisticResult, StatisticResultCollection, Summary
 from jetstream.bigquery_client import BigQueryClient
+from jetstream.experimenter import Branch
 
 logger = logging.getLogger(__name__)
 
@@ -27,14 +31,13 @@ class Analysis:
 
     project: str
     dataset: str
-    config: AnalysisConfiguration
 
     @property
     def bigquery(self):
         return BigQueryClient(project=self.project, dataset=self.dataset)
 
     def _get_timelimits_if_ready(
-        self, period: AnalysisPeriod, current_date: datetime
+        self, period: AnalysisPeriod, current_date: datetime, config: AnalysisConfiguration
     ) -> Optional[TimeLimits]:
         """
         Returns a TimeLimits instance if experiment is due for analysis.
@@ -44,13 +47,13 @@ class Analysis:
         prior_date_str = prior_date.strftime("%Y-%m-%d")
         current_date_str = current_date.strftime("%Y-%m-%d")
 
-        dates_enrollment = self.config.experiment.proposed_enrollment + 1
+        dates_enrollment = config.experiment.proposed_enrollment + 1
 
-        if self.config.experiment.start_date is None:
+        if config.experiment.start_date is None:
             return None
 
         time_limits_args = {
-            "first_enrollment_date": self.config.experiment.start_date.strftime("%Y-%m-%d"),
+            "first_enrollment_date": config.experiment.start_date.strftime("%Y-%m-%d"),
             "num_dates_enrollment": dates_enrollment,
         }
 
@@ -84,20 +87,15 @@ class Analysis:
             return current_time_limits
 
         assert period == AnalysisPeriod.OVERALL
-        if (
-            self.config.experiment.end_date != current_date
-            or self.config.experiment.status != "Complete"
-        ):
+        if config.experiment.end_date != current_date or config.experiment.status != "Complete":
             return None
 
         analysis_length_dates = (
-            (self.config.experiment.end_date - self.config.experiment.start_date).days
-            - dates_enrollment
-            + 1
+            (config.experiment.end_date - config.experiment.start_date).days - dates_enrollment + 1
         )
 
         if analysis_length_dates < 0:
-            raise errors.EnrollmentLongerThanAnalysisException(self.config.experiment.normandy_slug)
+            raise errors.EnrollmentLongerThanAnalysisException(config.experiment.normandy_slug)
 
         return TimeLimits.for_single_analysis_window(
             last_date_full_data=prior_date_str,
@@ -106,14 +104,14 @@ class Analysis:
             **time_limits_args,
         )
 
-    def _table_name(self, window_period: str, window_index: int) -> str:
-        assert self.config.experiment.normandy_slug is not None
-        normalized_slug = bq_normalize_name(self.config.experiment.normandy_slug)
+    def _table_name(self, window_period: str, window_index: int, normandy_slug: str) -> str:
+        assert normandy_slug is not None
+        normalized_slug = bq_normalize_name(normandy_slug)
         return "_".join([normalized_slug, window_period, str(window_index)])
 
-    def _publish_view(self, window_period: AnalysisPeriod, table_prefix=None):
-        assert self.config.experiment.normandy_slug is not None
-        normalized_slug = bq_normalize_name(self.config.experiment.normandy_slug)
+    def _publish_view(self, window_period: AnalysisPeriod, normandy_slug: str, table_prefix=None):
+        assert normandy_slug is not None
+        normalized_slug = bq_normalize_name(normandy_slug)
         view_name = "_".join([normalized_slug, window_period.adjective])
         wildcard_expr = "_".join([normalized_slug, window_period.value, "*"])
 
@@ -140,6 +138,10 @@ class Analysis:
         time_limits: TimeLimits,
         period: AnalysisPeriod,
         dry_run: bool,
+        enrollment_query: str,
+        segments: List[mozanalysis.segments.Segment],
+        normandy_slug: str,
+        metrics: MetricsConfigurationType,
     ):
         """
         Calculate metrics for a specific experiment.
@@ -157,143 +159,148 @@ class Analysis:
             ),
         )
 
-        res_table_name = self._table_name(period.value, window)
+        res_table_name = self._table_name(period.value, window, normandy_slug)
 
         sql = exp.build_query(
-            {m.metric for m in self.config.metrics[period]},
+            {m.metric for m in metrics[period]},
             last_window_limits,
             "normandy",
-            self.config.experiment.enrollment_query,
-            self.config.experiment.segments,
+            enrollment_query,
+            segments,
         )
 
         if dry_run:
             logger.info(
                 "Dry run; not actually calculating %s metrics for %s",
                 period.value,
-                self.config.experiment.normandy_slug,
+                normandy_slug,
             )
         else:
             logger.info(
                 "Executing query for %s (%s)",
-                self.config.experiment.normandy_slug,
+                normandy_slug,
                 period.value,
             )
             self.bigquery.execute(sql, res_table_name)
-            self._publish_view(period)
+            self._publish_view(period, normandy_slug)
 
         return res_table_name
 
-    def _calculate_statistics(self, metrics_table: str, period: AnalysisPeriod):
+    def _calculate_statistics(
+        self,
+        metric: Summary,
+        segment_data: DataFrame,
+        reference_branch: str,
+        normandy_slug: str,
+        segment: str,
+    ):
         """
-        Run statistics on metrics.
+        Run statistics on metric.
         """
+        stats = metric.run(segment_data, reference_branch, normandy_slug).set_segment(segment)
+        return stats.to_dict()["data"]
 
-        metrics_data = self.bigquery.table_to_dataframe(metrics_table)
-
-        results = []
-
-        segment_labels = ["all"] + [s.name for s in self.config.experiment.segments]
-        for segment in segment_labels:
-            if segment != "all":
-                if segment not in metrics_data.columns:
-                    logger.error(
-                        f"Segment {segment} not in metrics table",
-                        extra={"experiment": self.config.experiment.normandy_slug},
-                    )
-                    continue
-                segment_data = metrics_data[metrics_data[segment]]
-            else:
-                segment_data = metrics_data
-            for m in self.config.metrics[period]:
-                stats = m.run(segment_data, self.config.experiment).set_segment(segment)
-                results += stats.to_dict()["data"]
-
-            counts = (
-                Count()
-                .transform(segment_data, "*", "*", self.config.experiment)
-                .set_segment(segment)
-                .to_dict()["data"]
-            )
-            results += counts
-
-            # add count=0 row to statistics table for missing branches
-            missing_counts = StatisticResultCollection(
-                [
-                    StatisticResult(
-                        metric="identity",
-                        statistic="count",
-                        parameter=None,
-                        branch=b.slug,
-                        comparison=None,
-                        comparison_to_branch=None,
-                        ci_width=None,
-                        point=0,
-                        lower=None,
-                        upper=None,
-                        segment=segment,
-                    )
-                    for b in self.config.experiment.branches
-                    if b.slug not in {c["branch"] for c in counts}
-                ]
-            )
-
-            results += missing_counts.to_dict()["data"]
-
-        job_config = bigquery.LoadJobConfig()
-        job_config.schema = StatisticResult.bq_schema
-        job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
-
-        # wait for the job to complete
-        self.bigquery.load_table_from_json(
-            results, f"statistics_{metrics_table}", job_config=job_config
+    def _counts(self, segment_data: DataFrame, normandy_slug: str, segment: str):
+        """Count statistic."""
+        return (
+            Count()
+            .transform(segment_data, "*", "*", normandy_slug)
+            .set_segment(segment)
+            .to_dict()["data"]
         )
 
-        self._publish_view(period, table_prefix="statistics")
+    def _missing_counts(
+        self,
+        counts: List[Dict[str, Any]],
+        segment_data: DataFrame,
+        normandy_slug: str,
+        segment: str,
+        branches: List[Branch],
+    ):
+        """Missing count statistic."""
+        # add count=0 row to statistics table for missing branches
+        missing_counts = StatisticResultCollection(
+            [
+                StatisticResult(
+                    metric="identity",
+                    statistic="count",
+                    parameter=None,
+                    branch=b.slug,
+                    comparison=None,
+                    comparison_to_branch=None,
+                    ci_width=None,
+                    point=0,
+                    lower=None,
+                    upper=None,
+                    segment=segment,
+                )
+                for b in branches
+                if b.slug not in {c["branch"] for c in counts}
+            ]
+        )
 
-    def check_runnable(self, current_date: Optional[datetime] = None) -> bool:
-        if self.config.experiment.normandy_slug is None:
+        return missing_counts.to_dict()["data"]
+
+    def _segment_metrics(self, segment: str, metrics_data: DataFrame, normandy_slug):
+        """Return metrics data for segment"""
+        if segment != "all":
+            if segment not in metrics_data.columns:
+                logger.error(
+                    f"Segment {segment} not in metrics table",
+                    extra={"experiment": normandy_slug},
+                )
+                return
+            segment_data = metrics_data[metrics_data[segment]]
+        else:
+            segment_data = metrics_data
+
+        return segment_data
+
+    def check_runnable(
+        self, config: AnalysisConfiguration, current_date: Optional[datetime] = None
+    ) -> bool:
+        if config.experiment.normandy_slug is None:
             # some experiments do not have a normandy slug
             raise errors.NoSlugException()
 
-        if self.config.experiment.is_high_population:
-            raise errors.HighPopulationException(self.config.experiment.normandy_slug)
+        if config.experiment.is_high_population:
+            raise errors.HighPopulationException(config.experiment.normandy_slug)
 
-        if not self.config.experiment.proposed_enrollment:
-            raise errors.NoEnrollmentPeriodException(self.config.experiment.normandy_slug)
+        if not config.experiment.proposed_enrollment:
+            raise errors.NoEnrollmentPeriodException(config.experiment.normandy_slug)
 
-        if self.config.experiment.start_date is None:
-            raise errors.NoStartDateException(self.config.experiment.normandy_slug)
+        if config.experiment.start_date is None:
+            raise errors.NoStartDateException(config.experiment.normandy_slug)
 
         if (
             current_date
-            and self.config.experiment.end_date
-            and self.config.experiment.end_date < current_date
+            and config.experiment.end_date
+            and config.experiment.end_date < current_date
         ):
-            raise errors.EndedException(self.config.experiment.normandy_slug)
+            raise errors.EndedException(config.experiment.normandy_slug)
 
         return True
 
-    def validate(self) -> None:
-        self.check_runnable()
+    def validate(self, config: AnalysisConfiguration) -> None:
+        self.check_runnable(config)
 
-        dates_enrollment = self.config.experiment.proposed_enrollment + 1
+        dates_enrollment = config.experiment.proposed_enrollment + 1
 
-        if self.config.experiment.end_date is not None:
-            end_date = self.config.experiment.end_date
+        if config.experiment.end_date is not None:
+            end_date = config.experiment.end_date
             analysis_length_dates = (
-                (end_date - self.config.experiment.start_date).days - dates_enrollment + 1
+                (end_date - config.experiment.start_date).days - dates_enrollment + 1
             )
         else:
             analysis_length_dates = 21  # arbitrary
-            end_date = self.config.experiment.start_date + timedelta(
+            end_date = config.experiment.start_date + timedelta(
                 days=analysis_length_dates + dates_enrollment - 1
             )
 
         if analysis_length_dates < 0:
             logging.error(
                 "Proposed enrollment longer than analysis dates length:"
-                + f"{self.config.experiment.normandy_slug}"
+                + f"{config.experiment.normandy_slug}"
             )
             raise Exception("Cannot validate experiment")
 
@@ -301,65 +308,141 @@ class Analysis:
             last_date_full_data=end_date.strftime("%Y-%m-%d"),
             analysis_start_days=0,
             analysis_length_dates=analysis_length_dates,
-            first_enrollment_date=self.config.experiment.start_date.strftime("%Y-%m-%d"),
+            first_enrollment_date=config.experiment.start_date.strftime("%Y-%m-%d"),
             num_dates_enrollment=dates_enrollment,
         )
 
         exp = mozanalysis.experiment.Experiment(
-            experiment_slug=self.config.experiment.normandy_slug,
-            start_date=self.config.experiment.start_date.strftime("%Y-%m-%d"),
+            experiment_slug=config.experiment.normandy_slug,
+            start_date=config.experiment.start_date.strftime("%Y-%m-%d"),
         )
 
         metrics = set()
-        for v in self.config.metrics.values():
+        for v in config.metrics.values():
             metrics |= {m.metric for m in v}
 
         sql = exp.build_query(
             metrics,
             limits,
             "normandy",
-            self.config.experiment.enrollment_query,
+            config.experiment.enrollment_query,
         )
 
         dry_run_query(sql)
 
-    def run(self, current_date: datetime, dry_run: bool = False) -> None:
+    def _save_statistics(
+        self,
+        period: AnalysisPeriod,
+        segment_results: List[Dict[str, Any]],
+        metrics_table: str,
+        normandy_slug: str,
+    ):
+        """Write statistics to BigQuery."""
+        job_config = bigquery.LoadJobConfig()
+        job_config.schema = StatisticResult.bq_schema
+        job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
+
+        # wait for the job to complete
+        self.bigquery.load_table_from_json(
+            segment_results, f"statistics_{metrics_table}", job_config=job_config
+        )
+
+        self._publish_view(period, normandy_slug=normandy_slug, table_prefix="statistics")
+
+    def run(
+        self, current_date: datetime, config: AnalysisConfiguration, dry_run: bool = False
+    ) -> None:
         """
         Run analysis using mozanalysis for a specific experiment.
         """
-        logger.info("Analysis.run invoked for experiment %s", self.config.experiment.normandy_slug)
+        logger.info("Analysis.run invoked for experiment %s", config.experiment.normandy_slug)
 
-        self.check_runnable(current_date)
+        self.check_runnable(config, current_date)
 
-        for period in self.config.metrics:
-            time_limits = self._get_timelimits_if_ready(period, current_date)
+        # set up dask
+        cluster = LocalCluster(
+            dashboard_address="127.0.0.1:8782", processes=True, threads_per_worker=1
+        )
+        client = Client(cluster)
+
+        # prepare dask tasks
+        results = []
+        calculate_metrics = dask.delayed(self._calculate_metrics)
+        calculate_statistics = dask.delayed(self._calculate_statistics)
+        segment_metrics = dask.delayed(self._segment_metrics)
+        missing_counts = dask.delayed(self._missing_counts)
+        counts = dask.delayed(self._counts)
+        table_to_dataframe = dask.delayed(self.bigquery.table_to_dataframe)
+        save_statistics = dask.delayed(self._save_statistics)
+
+        for period in config.metrics:
+            time_limits = self._get_timelimits_if_ready(period, current_date, config)
 
             if time_limits is None:
                 logger.info(
                     "Skipping %s (%s); not ready",
-                    self.config.experiment.normandy_slug,
+                    config.experiment.normandy_slug,
                     period.value,
                 )
                 continue
 
             exp = mozanalysis.experiment.Experiment(
-                experiment_slug=self.config.experiment.normandy_slug,
-                start_date=self.config.experiment.start_date.strftime("%Y-%m-%d"),
+                experiment_slug=config.experiment.normandy_slug,
+                start_date=config.experiment.start_date.strftime("%Y-%m-%d"),
             )
 
-            metrics_table = self._calculate_metrics(exp, time_limits, period, dry_run)
+            metrics_table = calculate_metrics(
+                exp,
+                time_limits,
+                period,
+                dry_run,
+                config.experiment.enrollment_query,
+                config.experiment.segments,
+                config.experiment.normandy_slug,
+                config.metrics,
+            )
 
             if dry_run:
                 logger.info(
                     "Not calculating statistics %s (%s); dry run",
-                    self.config.experiment.normandy_slug,
+                    config.experiment.normandy_slug,
                     period.value,
                 )
                 continue
 
-            self._calculate_statistics(metrics_table, period)
-            logger.info(
-                "Finished running query for %s (%s)",
-                self.config.experiment.normandy_slug,
-                period.value,
+            metrics_data = table_to_dataframe(metrics_table)
+
+            segment_results = []
+
+            segment_labels = ["all"] + [s.name for s in config.experiment.segments]
+            for segment in segment_labels:
+                segment_data = segment_metrics(
+                    segment, metrics_data, config.experiment.normandy_slug
+                )
+                for m in config.metrics[period]:
+                    segment_results += calculate_statistics(
+                        m,
+                        segment_data,
+                        config.experiment.reference_branch,
+                        config.experiment.normandy_slug,
+                        segment,
+                    )
+
+                c = counts(segment_data, config.experiment.normandy_slug, segment)
+                segment_results += c
+                segment_results += missing_counts(
+                    c,
+                    segment_data,
+                    config.experiment.normandy_slug,
+                    segment,
+                    config.experiment.branches,
+                )
+
+            results.append(
+                save_statistics(
+                    period, segment_results, metrics_table, config.experiment.normandy_slug
+                )
             )
+
+        result_futures = client.compute(results)
+        client.gather(result_futures)  # block until futures have finished

--- a/jetstream/argo.py
+++ b/jetstream/argo.py
@@ -1,13 +1,14 @@
-from argo.workflows.client import ApiClient, Configuration, V1alpha1Api
 import base64
-from google.cloud.container_v1 import ClusterManagerClient
-import google.auth
 import logging
+import time
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-import time
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
+import google.auth
 import yaml
+from argo.workflows.client import ApiClient, Configuration, V1alpha1Api
+from google.cloud.container_v1 import ClusterManagerClient
 
 logger = logging.getLogger(__name__)
 

--- a/jetstream/bigquery_client.py
+++ b/jetstream/bigquery_client.py
@@ -1,6 +1,6 @@
-from datetime import datetime
 import re
 import time
+from datetime import datetime
 from typing import Dict, Iterable, Mapping, Optional
 
 import attr
@@ -9,8 +9,8 @@ import google.cloud.bigquery.client
 import google.cloud.bigquery.dataset
 import google.cloud.bigquery.job
 import google.cloud.bigquery.table
-from google.cloud.bigquery_storage import BigQueryReadClient
 import pandas as pd
+from google.cloud.bigquery_storage import BigQueryReadClient
 
 from . import AnalysisPeriod, bq_normalize_name
 

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -138,7 +138,7 @@ class SerialExecutorStrategy:
                         spec.merge(external_spec)
 
                 config = spec.resolve(experiment)
-                self.analysis_class(self.project_id, self.dataset_id).run(date, config)
+                self.analysis_class(self.project_id, self.dataset_id, config).run(date)
             except Exception as e:
                 failed = True
                 logger.exception(str(e), exc_info=e, extra={"experiment": slug})

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timedelta
-import os
-from pathlib import Path
 import logging
+import os
 import sys
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Callable, Iterable, Mapping, Optional, Protocol, TextIO, Tuple, Type, Union
 
 import attr
@@ -10,14 +10,14 @@ import click
 import pytz
 import toml
 
+from .analysis import Analysis
 from .argo import submit_workflow
+from .bigquery_client import BigQueryClient
 from .config import AnalysisSpec
 from .experimenter import ExperimentCollection
 from .export_json import export_statistics_tables
-from .analysis import Analysis
 from .external_config import ExternalConfigCollection
 from .logging.bigquery_log_handler import BigQueryLogHandler
-from .bigquery_client import BigQueryClient
 from .util import inclusive_date_range
 
 

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -138,7 +138,7 @@ class SerialExecutorStrategy:
                         spec.merge(external_spec)
 
                 config = spec.resolve(experiment)
-                self.analysis_class(self.project_id, self.dataset_id, config).run(date)
+                self.analysis_class(self.project_id, self.dataset_id).run(date, config)
             except Exception as e:
                 failed = True
                 logger.exception(str(e), exc_info=e, extra={"experiment": slug})

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -18,28 +18,29 @@ Definition and Reference classes are also direct representations of the configur
 which produce concrete mozanalysis classes when resolved.
 """
 
+import copy
 import datetime as dt
 from inspect import isabstract
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, List, Mapping, Optional, Type, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Type, TypeVar
 
 import attr
 import cattr
-import copy
 import jinja2
-from jinja2 import StrictUndefined
 import mozanalysis.metrics
 import mozanalysis.metrics.desktop
 import mozanalysis.segments
 import mozanalysis.segments.desktop
-import toml
 import pytz
+import toml
+from jinja2 import StrictUndefined
+
+from jetstream.errors import NoStartDateException
+from jetstream.pre_treatment import PreTreatment
+from jetstream.statistics import Statistic, Summary
 
 from . import AnalysisPeriod, nimbus
-from jetstream.errors import NoStartDateException
-from jetstream.statistics import Summary, Statistic
-from jetstream.pre_treatment import PreTreatment
 
 if TYPE_CHECKING:
     import jetstream.experimenter

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -242,7 +242,17 @@ class ExperimentConfiguration:
             raise NoStartDateException(self.normandy_slug)
         return (self.start_date + dt.timedelta(days=self.proposed_enrollment)).strftime("%Y-%m-%d")
 
+    # see https://stackoverflow.com/questions/50888391/pickle-of-object-with-getattr-method-in-
+    # python-returns-typeerror-object-no
+    def __getstate__(self):
+        return vars(self)
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+
     def __getattr__(self, name: str) -> Any:
+        if "experimenter_experiment" not in vars(self):
+            raise AttributeError
         return getattr(self.experimenter_experiment, name)
 
 

--- a/jetstream/dryrun.py
+++ b/jetstream/dryrun.py
@@ -11,9 +11,10 @@ accidentally running queries during tests, leaking and overwriting production
 data, we proxy the queries through the dry run service endpoint.
 """
 
-import requests
 import json
 import logging
+
+import requests
 
 logger = logging.getLogger(__name__)
 

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -1,12 +1,12 @@
 import datetime as dt
-from typing import Any, List, Iterable, Mapping, Optional, Union
+import logging
+import time
+from typing import Any, Iterable, List, Mapping, Optional, Union
 
 import attr
 import cattr
-import logging
-import requests
 import pytz
-import time
+import requests
 
 logger = logging.getLogger(__name__)
 

--- a/jetstream/export_json.py
+++ b/jetstream/export_json.py
@@ -1,10 +1,9 @@
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import Dict, Optional
 
-from google.cloud import bigquery
-from google.cloud import storage
 import smart_open
+from google.cloud import bigquery, storage
 
 from jetstream import AnalysisPeriod, bq_normalize_name
 

--- a/jetstream/external_config.py
+++ b/jetstream/external_config.py
@@ -8,14 +8,15 @@ import datetime as dt
 from typing import List, Optional
 
 import attr
+import toml
 from git import Repo
 from google.cloud import bigquery
 from pytz import UTC
-import toml
 
-from . import bq_normalize_name
 from jetstream.config import AnalysisSpec
 from jetstream.util import TemporaryDirectory
+
+from . import bq_normalize_name
 
 
 @attr.s(auto_attribs=True)

--- a/jetstream/logging/bigquery_log_handler.py
+++ b/jetstream/logging/bigquery_log_handler.py
@@ -1,7 +1,8 @@
 import datetime
-from google.cloud import bigquery
 from logging.handlers import BufferingHandler
 from typing import Optional
+
+from google.cloud import bigquery
 
 
 class BigQueryLogHandler(BufferingHandler):

--- a/jetstream/nimbus.py
+++ b/jetstream/nimbus.py
@@ -1,24 +1,14 @@
 import re
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Protocol,
-    Union,
-)
+from typing import Any, ClassVar, Dict, Iterable, List, Mapping, Optional, Protocol, Union
 
 import attr
 import cattr
+import mozanalysis.metrics.desktop
+import toml
 from git import Repo
 from google.cloud import bigquery
 from google.cloud.bigquery.schema import SchemaField
 from mozanalysis.metrics import Metric
-import mozanalysis.metrics.desktop
-import toml
 
 from . import statistics
 from .util import TemporaryDirectory

--- a/jetstream/pre_treatment.py
+++ b/jetstream/pre_treatment.py
@@ -1,8 +1,8 @@
-from abc import ABC, abstractmethod
-import attr
 import re
-from typing import Optional, Dict, Any
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
 
+import attr
 import numpy as np
 import pandas as pd
 from pandas import DataFrame

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -41,15 +41,13 @@ class Summary:
     pre_treatments: List[PreTreatment] = attr.Factory(list)
 
     def run(
-        self,
-        data: DataFrame,
-        experiment: "config.ExperimentConfiguration",
+        self, data: DataFrame, reference_branch: str, normandy_slug: str
     ) -> "StatisticResultCollection":
         """Apply the statistic transformation for data related to the specified metric."""
         for pre_treatment in self.pre_treatments:
             data = pre_treatment.apply(data, self.metric.name)
 
-        return self.statistic.apply(data, self.metric.name, experiment)
+        return self.statistic.apply(data, self.metric.name, normandy_slug, reference_branch)
 
 
 @attr.s(auto_attribs=True)
@@ -127,10 +125,7 @@ class Statistic(ABC):
         return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()
 
     def apply(
-        self,
-        df: DataFrame,
-        metric: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, normandy_slug: str, reference_branch: str
     ) -> "StatisticResultCollection":
         """
         Run statistic on data provided by a DataFrame and return a collection
@@ -141,11 +136,11 @@ class Statistic(ABC):
 
         if metric in df:
             branch_list = df.branch.unique()
-            reference_branch = experiment.reference_branch
+            reference_branch = reference_branch
             if reference_branch and reference_branch not in branch_list:
                 logger.warning(
                     f"Branch {reference_branch} not in {branch_list} for {self.name()}.",
-                    extra={"experiment": experiment.normandy_slug},
+                    extra={"experiment": normandy_slug},
                 )
             else:
                 if reference_branch is None:
@@ -155,7 +150,7 @@ class Statistic(ABC):
 
                 for ref_branch in ref_branch_list:
                     statistic_result_collection.data += self.transform(
-                        df, metric, ref_branch, experiment
+                        df, metric, ref_branch, normandy_slug
                     ).data
                     df = df[df.branch != ref_branch]
 
@@ -163,11 +158,7 @@ class Statistic(ABC):
 
     @abstractmethod
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> "StatisticResultCollection":
         return NotImplemented
 
@@ -266,11 +257,7 @@ class BootstrapMean(Statistic):
     confidence_interval: float = 0.95
 
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> StatisticResultCollection:
         critical_point = (1 - self.confidence_interval) / 2
         summary_quantiles = (critical_point, 1 - critical_point)
@@ -298,11 +285,7 @@ class Binomial(Statistic):
     confidence_interval: float = 0.95
 
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> StatisticResultCollection:
         critical_point = (1 - self.confidence_interval) / 2
         summary_quantiles = (critical_point, 1 - critical_point)
@@ -340,11 +323,7 @@ class Deciles(Statistic):
         return arr_dict
 
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> StatisticResultCollection:
         stats_results = StatisticResultCollection([])
 
@@ -418,20 +397,11 @@ class Deciles(Statistic):
 
 
 class Count(Statistic):
-    def apply(
-        self,
-        df: DataFrame,
-        metric: str,
-        experiment: "config.ExperimentConfiguration",
-    ):
-        return self.transform(df, metric, experiment.reference_branch or "control", experiment)
+    def apply(self, df: DataFrame, metric: str, normandy_slug: str, reference_branch: str):
+        return self.transform(df, metric, reference_branch or "control", normandy_slug)
 
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> StatisticResultCollection:
         results = []
         counts = df.groupby("branch").size()
@@ -489,11 +459,7 @@ class KernelDensityEstimate(Statistic):
     log_space: bool = False
 
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> StatisticResultCollection:
         results = []
         for branch, group in df.groupby("branch"):
@@ -545,11 +511,7 @@ class EmpiricalCDF(Statistic):
     grid_size: int = 256
 
     def transform(
-        self,
-        df: DataFrame,
-        metric: str,
-        reference_branch: str,
-        experiment: "config.ExperimentConfiguration",
+        self, df: DataFrame, metric: str, reference_branch: str, normandy_slug: str
     ) -> StatisticResultCollection:
         results = []
         for branch, group in df.groupby("branch"):

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -1,20 +1,20 @@
-from abc import ABC, abstractmethod
-from decimal import Decimal
 import logging
 import math
 import re
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from abc import ABC, abstractmethod
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import attr
 import cattr
-from google.cloud import bigquery
-import mozanalysis.bayesian_stats.binary
 import mozanalysis.bayesian_stats.bayesian_bootstrap
+import mozanalysis.bayesian_stats.binary
 import mozanalysis.frequentist_stats.bootstrap
 import mozanalysis.metrics
 import numpy as np
-from pandas import DataFrame, Series
 import statsmodels.api as sm
+from google.cloud import bigquery
+from pandas import DataFrame, Series
 from statsmodels.distributions.empirical_distribution import ECDF
 
 from .pre_treatment import PreTreatment

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -17,7 +17,6 @@ from pandas import DataFrame, Series
 import statsmodels.api as sm
 from statsmodels.distributions.empirical_distribution import ECDF
 
-from . import config
 from .pre_treatment import PreTreatment
 
 if TYPE_CHECKING:

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pytest
 import pytz
 
-from jetstream.experimenter import Experiment, Branch
+from jetstream.experimenter import Branch, Experiment
 
 
 def pytest_addoption(parser):

--- a/jetstream/tests/integration/conftest.py
+++ b/jetstream/tests/integration/conftest.py
@@ -1,9 +1,10 @@
-from google.cloud import bigquery
-from google.api_core.exceptions import NotFound
-from pathlib import Path
-import pytest
 import random
 import string
+from pathlib import Path
+
+import pytest
+from google.api_core.exceptions import NotFound
+from google.cloud import bigquery
 
 from jetstream.bigquery_client import BigQueryClient
 

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -1,20 +1,19 @@
+import datetime
 import datetime as dt
 from pathlib import Path
-import dask
-import datetime
 from unittest import mock
 
+import dask
 import mozanalysis
-from mozanalysis.segments import Segment, SegmentDataSource
-from mozanalysis.metrics import Metric, DataSource, agg_sum
 import pytz
+from mozanalysis.metrics import DataSource, Metric, agg_sum
+from mozanalysis.segments import Segment, SegmentDataSource
 
 from jetstream import AnalysisPeriod
 from jetstream.analysis import Analysis
 from jetstream.config import AnalysisSpec, Summary
-from jetstream.experimenter import Experiment, Branch
+from jetstream.experimenter import Branch, Experiment
 from jetstream.statistics import BootstrapMean
-
 
 TEST_DIR = Path(__file__).parent.parent
 

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -111,10 +111,8 @@ class TestAnalysisIntegration:
         ]
 
         r = query_job.result()
-        print(r)
 
         for i, row in enumerate(r):
-            print(row)
             for k, v in expected_metrics_results[i].items():
                 assert row[k] == v
 
@@ -132,8 +130,6 @@ class TestAnalysisIntegration:
         stats = client.client.list_rows(
             f"{project_id}.{temporary_dataset}.statistics_test_experiment_week_1"
         ).to_dataframe()
-
-        print(stats)
 
         count_by_branch = stats.query("statistic == 'count'").set_index("branch")
         assert count_by_branch.loc["branch1", "point"] == 1.0

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -59,8 +59,8 @@ class TestAnalysisIntegration:
             end_date=dt.datetime(2020, 6, 1, tzinfo=pytz.utc),
             proposed_enrollment=7,
             branches=[Branch(slug="branch1", ratio=0.5), Branch(slug="branch2", ratio=0.5)],
-            reference_branch="branch2",
             probe_sets=[],
+            reference_branch="branch2",
             normandy_slug="test-experiment",
             is_high_population=False,
         )
@@ -149,8 +149,8 @@ class TestAnalysisIntegration:
             end_date=dt.datetime(2020, 6, 1, tzinfo=pytz.utc),
             proposed_enrollment=7,
             branches=[Branch(slug="a", ratio=0.5), Branch(slug="b", ratio=0.5)],
-            reference_branch="a",
             probe_sets=[],
+            reference_branch="a",
             normandy_slug="test-experiment-2",
             is_high_population=False,
         )
@@ -194,8 +194,8 @@ class TestAnalysisIntegration:
             end_date=dt.datetime(2020, 6, 1, tzinfo=pytz.utc),
             proposed_enrollment=7,
             branches=[Branch(slug="branch1", ratio=0.5), Branch(slug="branch2", ratio=0.5)],
-            reference_branch="branch2",
             probe_sets=[],
+            reference_branch="branch2",
             normandy_slug="test-experiment",
             is_high_population=False,
         )

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -34,6 +34,7 @@ class TestAnalysisIntegration:
         orig_cluster = dask.distributed.LocalCluster.__init__
 
         def mock_local_cluster(instance, dashboard_address, processes, threads_per_worker):
+            # if processes are used then `build_query_test_project` gets ignored
             return orig_cluster(
                 instance,
                 dashboard_address=dashboard_address,
@@ -110,7 +111,11 @@ class TestAnalysisIntegration:
             },
         ]
 
-        for i, row in enumerate(query_job.result()):
+        r = query_job.result()
+        print(r)
+
+        for i, row in enumerate(r):
+            print(row)
             for k, v in expected_metrics_results[i].items():
                 assert row[k] == v
 
@@ -128,6 +133,8 @@ class TestAnalysisIntegration:
         stats = client.client.list_rows(
             f"{project_id}.{temporary_dataset}.statistics_test_experiment_week_1"
         ).to_dataframe()
+
+        print(stats)
 
         count_by_branch = stats.query("statistic == 'count'").set_index("branch")
         assert count_by_branch.loc["branch1", "point"] == 1.0

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -41,14 +41,14 @@ class TestAnalysisIntegration:
                 threads_per_worker=threads_per_worker,
             )
 
-        analysis = Analysis(project_id, temporary_dataset)
+        analysis = Analysis(project_id, temporary_dataset, config)
         with mock.patch.object(
             mozanalysis.experiment.Experiment, "build_query", new=build_query_test_project
         ):
             with mock.patch.object(
                 dask.distributed.LocalCluster, "__init__", new=mock_local_cluster
             ):
-                analysis.run(dt.datetime(2020, 4, 12, tzinfo=pytz.utc), config, dry_run=False)
+                analysis.run(dt.datetime(2020, 4, 12, tzinfo=pytz.utc), dry_run=False)
 
     def test_metrics(self, client, project_id, static_dataset, temporary_dataset):
         experiment = Experiment(

--- a/jetstream/tests/integration/test_external_config_integration.py
+++ b/jetstream/tests/integration/test_external_config_integration.py
@@ -1,12 +1,12 @@
-from pathlib import Path
 import datetime
-import pytz
+from pathlib import Path
 from textwrap import dedent
+
+import pytz
 import toml
 
-
-from jetstream.external_config import ExternalConfig, ExternalConfigCollection
 from jetstream.config import AnalysisSpec
+from jetstream.external_config import ExternalConfig, ExternalConfigCollection
 
 TEST_DIR = Path(__file__).parent.parent
 

--- a/jetstream/tests/integration/test_logging_integration.py
+++ b/jetstream/tests/integration/test_logging_integration.py
@@ -1,6 +1,7 @@
-from google.cloud import bigquery
-import pytest
 import logging
+
+import pytest
+from google.cloud import bigquery
 
 from jetstream.cli import setup_logger
 

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -20,6 +20,7 @@ from jetstream.errors import HighPopulationException
 def test_get_timelimits_if_ready(experiments):
     config = AnalysisSpec().resolve(experiments[0])
     config2 = AnalysisSpec().resolve(experiments[2])
+
     analysis = Analysis("test", "test", config)
     analysis2 = Analysis("test", "test", config2)
 
@@ -82,7 +83,7 @@ def test_regression_20200320():
     config = AnalysisSpec().resolve(experiment)
     analysis = Analysis("test", "test", config)
     with pytest.raises(NoEnrollmentPeriodException):
-        analysis.run(dt.datetime(2020, 3, 19, tzinfo=pytz.utc), dry_run=True)
+        analysis.run(current_date=dt.datetime(2020, 3, 19, tzinfo=pytz.utc), dry_run=True)
 
 
 def test_regression_20200316():
@@ -142,7 +143,7 @@ def test_regression_20200316():
     experiment = ExperimentV1.from_dict(json.loads(experiment_json)).to_experiment()
     config = AnalysisSpec().resolve(experiment)
     analysis = Analysis("test", "test", config)
-    analysis.run(dt.datetime(2020, 3, 16, tzinfo=pytz.utc), dry_run=True)
+    analysis.run(current_date=dt.datetime(2020, 3, 16, tzinfo=pytz.utc), dry_run=True)
 
 
 def test_validate_doesnt_explode(experiments, monkeypatch):
@@ -164,7 +165,9 @@ def test_analysis_doesnt_choke_on_segments(experiments):
     spec = AnalysisSpec.from_dict(toml.loads(conf))
     configured = spec.resolve(experiments[0])
     assert isinstance(configured.experiment.segments[0], mozanalysis.segments.Segment)
-    Analysis("test", "test", configured).run(dt.datetime(2020, 1, 1, tzinfo=pytz.utc), dry_run=True)
+    Analysis("test", "test", configured).run(
+        current_date=dt.datetime(2020, 1, 1, tzinfo=pytz.utc), dry_run=True
+    )
 
 
 def test_is_high_population_check(experiments):

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -1,20 +1,19 @@
 import datetime as dt
-from datetime import timedelta
 import json
-import pytest
-from unittest.mock import Mock
+from datetime import timedelta
 from textwrap import dedent
+from unittest.mock import Mock
 
 import mozanalysis.segments
+import pytest
 import pytz
 import toml
 
 import jetstream.analysis
 from jetstream.analysis import Analysis, AnalysisPeriod
-from jetstream.errors import NoEnrollmentPeriodException
 from jetstream.config import AnalysisSpec
+from jetstream.errors import HighPopulationException, NoEnrollmentPeriodException
 from jetstream.experimenter import ExperimentV1
-from jetstream.errors import HighPopulationException
 
 
 def test_get_timelimits_if_ready(experiments):

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -20,31 +20,31 @@ from jetstream.errors import HighPopulationException
 def test_get_timelimits_if_ready(experiments):
     config = AnalysisSpec().resolve(experiments[0])
     config2 = AnalysisSpec().resolve(experiments[2])
-
-    analysis = Analysis("test", "test")
+    analysis = Analysis("test", "test", config)
+    analysis2 = Analysis("test", "test", config2)
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(0)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date, config) is None
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date, config) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date) is None
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(2)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date, config) is None
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date, config) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date) is None
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(7)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date, config)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date, config) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date)
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date) is None
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(days=13)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date, config)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date, config)
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date)
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date)
 
     date = dt.datetime(2020, 2, 29, tzinfo=pytz.utc)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date, config) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date) is None
 
     date = dt.datetime(2020, 3, 1, tzinfo=pytz.utc)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date, config)
-    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date, config2) is None
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date)
+    assert analysis2._get_timelimits_if_ready(AnalysisPeriod.OVERALL, date) is None
 
 
 def test_regression_20200320():
@@ -80,9 +80,9 @@ def test_regression_20200320():
     """  # noqa
     experiment = ExperimentV1.from_dict(json.loads(experiment_json)).to_experiment()
     config = AnalysisSpec().resolve(experiment)
-    analysis = Analysis("test", "test")
+    analysis = Analysis("test", "test", config)
     with pytest.raises(NoEnrollmentPeriodException):
-        analysis.run(dt.datetime(2020, 3, 19, tzinfo=pytz.utc), config, dry_run=True)
+        analysis.run(dt.datetime(2020, 3, 19, tzinfo=pytz.utc), dry_run=True)
 
 
 def test_regression_20200316():
@@ -141,8 +141,8 @@ def test_regression_20200316():
     """
     experiment = ExperimentV1.from_dict(json.loads(experiment_json)).to_experiment()
     config = AnalysisSpec().resolve(experiment)
-    analysis = Analysis("test", "test")
-    analysis.run(dt.datetime(2020, 3, 16, tzinfo=pytz.utc), config, dry_run=True)
+    analysis = Analysis("test", "test", config)
+    analysis.run(dt.datetime(2020, 3, 16, tzinfo=pytz.utc), dry_run=True)
 
 
 def test_validate_doesnt_explode(experiments, monkeypatch):
@@ -150,7 +150,7 @@ def test_validate_doesnt_explode(experiments, monkeypatch):
     monkeypatch.setattr(jetstream.analysis, "dry_run_query", m)
     x = experiments[0]
     config = AnalysisSpec.default_for_experiment(x).resolve(x)
-    Analysis("spam", "eggs").validate(config)
+    Analysis("spam", "eggs", config).validate()
     m.assert_called_once()
 
 
@@ -164,7 +164,7 @@ def test_analysis_doesnt_choke_on_segments(experiments):
     spec = AnalysisSpec.from_dict(toml.loads(conf))
     configured = spec.resolve(experiments[0])
     assert isinstance(configured.experiment.segments[0], mozanalysis.segments.Segment)
-    Analysis("test", "test").run(dt.datetime(2020, 1, 1, tzinfo=pytz.utc), configured, dry_run=True)
+    Analysis("test", "test", configured).run(dt.datetime(2020, 1, 1, tzinfo=pytz.utc), dry_run=True)
 
 
 def test_is_high_population_check(experiments):
@@ -172,4 +172,4 @@ def test_is_high_population_check(experiments):
     config = AnalysisSpec.default_for_experiment(x).resolve(x)
 
     with pytest.raises(HighPopulationException):
-        Analysis("spam", "eggs").check_runnable(config)
+        Analysis("spam", "eggs", config).check_runnable()

--- a/jetstream/tests/test_argo.py
+++ b/jetstream/tests/test_argo.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+
 import yaml
 
 from jetstream import argo

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -1,9 +1,9 @@
-import attr
 import datetime as dt
+from unittest.mock import Mock
 
+import attr
 import pytest
 from pytz import UTC
-from unittest.mock import Mock
 
 from jetstream import cli, experimenter, external_config
 from jetstream.config import AnalysisSpec

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -184,5 +184,5 @@ class TestSerialExecutorStrategy:
         )
         run_date = dt.datetime(2020, 10, 31, tzinfo=UTC)
         strategy.execute([(experiment.normandy_slug, run_date)])
-        fake_analysis.assert_called_once_with("spam", "eggs")
-        fake_analysis().run.assert_called_once_with(run_date, spec.resolve(experiment))
+        fake_analysis.assert_called_once_with("spam", "eggs", spec.resolve(experiment))
+        fake_analysis().run.assert_called_once_with(run_date)

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -184,5 +184,5 @@ class TestSerialExecutorStrategy:
         )
         run_date = dt.datetime(2020, 10, 31, tzinfo=UTC)
         strategy.execute([(experiment.normandy_slug, run_date)])
-        fake_analysis.assert_called_once_with("spam", "eggs", spec.resolve(experiment))
-        fake_analysis().run.assert_called_once_with(run_date)
+        fake_analysis.assert_called_once_with("spam", "eggs")
+        fake_analysis().run.assert_called_once_with(run_date, spec.resolve(experiment))

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -2,15 +2,15 @@ import datetime as dt
 from textwrap import dedent
 
 import mozanalysis.segments
-import toml
 import pytest
 import pytz
+import toml
 
 from jetstream import AnalysisPeriod, config
 from jetstream.config import DEFAULT_METRICS_CONFIG
 from jetstream.nimbus import Feature, FeatureEventTelemetry, FeatureScalarTelemetry
+from jetstream.pre_treatment import CensorHighestValues, Log, RemoveNulls
 from jetstream.statistics import BootstrapMean
-from jetstream.pre_treatment import RemoveNulls, CensorHighestValues, Log
 
 
 @pytest.fixture

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -8,9 +8,9 @@ import pytest
 import pytz
 
 from jetstream.experimenter import (
-    ExperimentCollection,
-    Experiment,
     Branch,
+    Experiment,
+    ExperimentCollection,
     ExperimentV1,
     ExperimentV6,
     Variant,

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -75,9 +75,7 @@ class TestStatistics:
                 + [True] * 5,
             }
         )
-        result = stat.apply(
-            test_data, "value", experiments[1].reference_branch, experiments[1].normandy_slug
-        )
+        result = stat.apply(test_data, "value", experiments[1])
 
         branch_results = [r for r in result.data if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -75,7 +75,9 @@ class TestStatistics:
                 + [True] * 5,
             }
         )
-        result = stat.apply(test_data, "value", experiments[1])
+        result = stat.apply(
+            test_data, "value", experiments[1].reference_branch, experiments[1].normandy_slug
+        )
 
         branch_results = [r for r in result.data if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -4,12 +4,12 @@ import pandas as pd
 import pytest
 
 from jetstream.statistics import (
-    _make_grid,
-    BootstrapMean,
     Binomial,
+    BootstrapMean,
     Count,
-    KernelDensityEstimate,
     EmpiricalCDF,
+    KernelDensityEstimate,
+    _make_grid,
 )
 
 

--- a/jetstream/util.py
+++ b/jetstream/util.py
@@ -1,8 +1,8 @@
+import shutil
+import tempfile
 from contextlib import contextmanager
 from datetime import timedelta
 from pathlib import Path
-import shutil
-import tempfile
 
 # based on https://stackoverflow.com/a/22726782
 

--- a/requirements.in
+++ b/requirements.in
@@ -15,6 +15,7 @@ cffi==1.14.3              # via google-crc32c
 chardet==3.0.4            # via requests
 click==7.1.2              # via black, mozilla-jetstream
 coverage==5.3             # via mozilla-jetstream, pytest-cov
+dask[distributed]==2.30.0  # via mozilla-jetstream
 flake8==3.8.4             # via pytest-flake8
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.11         # via mozilla-jetstream

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,11 @@ chardet==3.0.4 \
 click==7.1.2 \
     --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a \
     --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc \
-    # via -r requirements.in, black
+    # via -r requirements.in, black, distributed
+cloudpickle==1.6.0 \
+    --hash=sha256:3a32d0eb0bc6f4d0c57fbc4f3e3780f7a81e6fee0fa935072884d58ae8e1cc7c \
+    --hash=sha256:9bc994f9e9447593bd0a45371f0e7ac7333710fcf64a4eb9834bf149f4ef2f32 \
+    # via distributed
 coverage==5.3 \
     --hash=sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516 \
     --hash=sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259 \
@@ -114,6 +118,14 @@ coverage==5.3 \
     --hash=sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636 \
     --hash=sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8 \
     # via -r requirements.in, pytest-cov
+dask[distributed]==2.30.0 \
+    --hash=sha256:4c215aa55951f570b5a294b2ce964ed801c6efd766231c53447460e60f73ea14 \
+    --hash=sha256:a1669022e25de99b227c3d83da4801f032415962dac431099bf0534648e41a54 \
+    # via -r requirements.in, distributed
+distributed==2.30.1 \
+    --hash=sha256:1421d3b84a0885aeb2c4bdc9e8896729c0f053a9375596c9de8864e055e2ac8e \
+    --hash=sha256:d922f4ea9becd27b823f47f008d11e7eb81ce832eeea14c7965e39aafd92dcc7 \
+    # via dask
 flake8==3.8.4 \
     --hash=sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839 \
     --hash=sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b \
@@ -231,6 +243,10 @@ grpcio==1.33.2 \
     --hash=sha256:fa78bd55ec652d4a88ba254c8dae623c9992e2ce647bd17ba1a37ca2b7b42222 \
     --hash=sha256:ffec0b854d2ed6ee98776c7168c778cdd18503642a68d36c00ba0f96d4ccff7c \
     # via -r requirements.in, google-api-core, googleapis-common-protos, grpc-google-iam-v1
+heapdict==1.0.1 \
+    --hash=sha256:6065f90933ab1bb7e50db403b90cab653c853690c5992e69294c2de2b253fc92 \
+    --hash=sha256:8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6 \
+    # via zict
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
@@ -306,6 +322,26 @@ mozanalysis==2020.9.1 \
     --hash=sha256:6bb718fe09ab9d1651010db22013244641c8eefaf6007db5d628c735b3fa21a1 \
     --hash=sha256:d166777246f0ff5b7c7ca7588360f36b4e03a85e8ce0d7f41ef923dda7794501 \
     # via -r requirements.in
+msgpack==1.0.0 \
+    --hash=sha256:002a0d813e1f7b60da599bdf969e632074f9eec1b96cbed8fb0973a63160a408 \
+    --hash=sha256:25b3bc3190f3d9d965b818123b7752c5dfb953f0d774b454fd206c18fe384fb8 \
+    --hash=sha256:271b489499a43af001a2e42f42d876bb98ccaa7e20512ff37ca78c8e12e68f84 \
+    --hash=sha256:39c54fdebf5fa4dda733369012c59e7d085ebdfe35b6cf648f09d16708f1be5d \
+    --hash=sha256:4233b7f86c1208190c78a525cd3828ca1623359ef48f78a6fea4b91bb995775a \
+    --hash=sha256:5bea44181fc8e18eed1d0cd76e355073f00ce232ff9653a0ae88cb7d9e643322 \
+    --hash=sha256:5dba6d074fac9b24f29aaf1d2d032306c27f04187651511257e7831733293ec2 \
+    --hash=sha256:7a22c965588baeb07242cb561b63f309db27a07382825fc98aecaf0827c1538e \
+    --hash=sha256:908944e3f038bca67fcfedb7845c4a257c7749bf9818632586b53bcf06ba4b97 \
+    --hash=sha256:9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0 \
+    --hash=sha256:aa5c057eab4f40ec47ea6f5a9825846be2ff6bf34102c560bad5cad5a677c5be \
+    --hash=sha256:b3758dfd3423e358bbb18a7cccd1c74228dffa7a697e5be6cb9535de625c0dbf \
+    --hash=sha256:c901e8058dd6653307906c5f157f26ed09eb94a850dddd989621098d347926ab \
+    --hash=sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08 \
+    --hash=sha256:db685187a415f51d6b937257474ca72199f393dad89534ebbdd7d7a3b000080e \
+    --hash=sha256:e35b051077fc2f3ce12e7c6a34cf309680c63a842db3a0616ea6ed25ad20d272 \
+    --hash=sha256:e7bbdd8e2b277b77782f3ce34734b0dfde6cbe94ddb74de8d733d603c7f9e2b1 \
+    --hash=sha256:ea41c9219c597f1d2bf6b374d951d310d58684b5de9dc4bd2976db9e1e22c140 \
+    # via distributed
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8 \
@@ -431,6 +467,19 @@ protobuf==3.13.0 \
     --hash=sha256:e7662437ca1e0c51b93cadb988f9b353fa6b8013c0385d63a70c8a77d84da5f9 \
     --hash=sha256:f68eb9d03c7d84bd01c790948320b768de8559761897763731294e3bc316decb \
     # via -r requirements.in, google-api-core, google-cloud-bigquery, googleapis-common-protos, proto-plus
+psutil==5.7.3 \
+    --hash=sha256:01bc82813fbc3ea304914581954979e637bcc7084e59ac904d870d6eb8bb2bc7 \
+    --hash=sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787 \
+    --hash=sha256:2cb55ef9591b03ef0104bedf67cc4edb38a3edf015cf8cf24007b99cb8497542 \
+    --hash=sha256:56c85120fa173a5d2ad1d15a0c6e0ae62b388bfb956bb036ac231fbdaf9e4c22 \
+    --hash=sha256:5d9106ff5ec2712e2f659ebbd112967f44e7d33f40ba40530c485cc5904360b8 \
+    --hash=sha256:6a3e1fd2800ca45083d976b5478a2402dd62afdfb719b30ca46cd28bb25a2eb4 \
+    --hash=sha256:ade6af32eb80a536eff162d799e31b7ef92ddcda707c27bbd077238065018df4 \
+    --hash=sha256:af73f7bcebdc538eda9cc81d19db1db7bf26f103f91081d780bbacfcb620dee2 \
+    --hash=sha256:e02c31b2990dcd2431f4524b93491941df39f99619b0d312dfe1d4d530b08b4b \
+    --hash=sha256:fa38ac15dbf161ab1e941ff4ce39abd64b53fec5ddf60c23290daed2bc7d1157 \
+    --hash=sha256:fbcac492cb082fa38d88587d75feb90785d05d7e12d4565cbf1ecc727aff71b7 \
+    # via distributed
 py==1.9.0 \
     --hash=sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2 \
     --hash=sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342 \
@@ -523,7 +572,7 @@ pyyaml==5.3.1 \
     --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d \
     --hash=sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c \
     --hash=sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a \
-    # via -r requirements.in, kubernetes, libcst
+    # via -r requirements.in, dask, distributed, kubernetes, libcst
 regex==2020.10.28 \
     --hash=sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a \
     --hash=sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f \
@@ -613,6 +662,10 @@ smmap==3.0.4 \
     --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4 \
     --hash=sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24 \
     # via -r requirements.in, gitdb
+sortedcontainers==2.2.2 \
+    --hash=sha256:4e73a757831fc3ca4de2859c422564239a31d8213d09a2a666e375807034d2ba \
+    --hash=sha256:c633ebde8580f241f274c1f8994a665c0e54a17724fecd0cae2f079e09c36d3f \
+    # via distributed
 statsmodels==0.12.1 \
     --hash=sha256:02679bf39d35a2aceb2d9f6d332b4e1cda1797157df792fe867b45f2a14d20d3 \
     --hash=sha256:142eacd5a1bd8728358ff48101ee0e51ca3d42a93f6e5cb61fcfacf613977bcf \
@@ -630,10 +683,61 @@ statsmodels==0.12.1 \
     --hash=sha256:e5e426fb962f41d58a07a7d2f7daf32f83e911ff578368caddbcdd1886887ed1 \
     --hash=sha256:ef3a54b3594f4c49c295388de1fdd840a8c63a857a5252125aaf92a03ea1e3a6 \
     # via -r requirements.in
+tblib==1.7.0 \
+    --hash=sha256:059bd77306ea7b419d4f76016aef6d7027cc8a0785579b5aad198803435f882c \
+    --hash=sha256:289fa7359e580950e7d9743eab36b0691f0310fce64dee7d9c31065b8f723e23 \
+    # via distributed
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f \
     # via -r requirements.in, black, pytest, pytest-black
+toolz==0.11.1 \
+    --hash=sha256:1bc473acbf1a1db4e72a1ce587be347450e8f08324908b8a266b486f408f04d5 \
+    --hash=sha256:c7a47921f07822fe534fb1c01c9931ab335a4390c782bd28c6bcc7c2f71f3fbf \
+    # via distributed
+tornado==6.1 \
+    --hash=sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb \
+    --hash=sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c \
+    --hash=sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288 \
+    --hash=sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95 \
+    --hash=sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558 \
+    --hash=sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe \
+    --hash=sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791 \
+    --hash=sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d \
+    --hash=sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326 \
+    --hash=sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b \
+    --hash=sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4 \
+    --hash=sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c \
+    --hash=sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910 \
+    --hash=sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5 \
+    --hash=sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c \
+    --hash=sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0 \
+    --hash=sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675 \
+    --hash=sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd \
+    --hash=sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f \
+    --hash=sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c \
+    --hash=sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea \
+    --hash=sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6 \
+    --hash=sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05 \
+    --hash=sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd \
+    --hash=sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575 \
+    --hash=sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a \
+    --hash=sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37 \
+    --hash=sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795 \
+    --hash=sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f \
+    --hash=sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32 \
+    --hash=sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c \
+    --hash=sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01 \
+    --hash=sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4 \
+    --hash=sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2 \
+    --hash=sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921 \
+    --hash=sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085 \
+    --hash=sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df \
+    --hash=sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102 \
+    --hash=sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5 \
+    --hash=sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68 \
+    --hash=sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5 \
+    # via distributed
 typed-ast==1.4.1 \
     --hash=sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355 \
     --hash=sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919 \
@@ -675,6 +779,10 @@ websocket-client==0.57.0 \
     --hash=sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549 \
     --hash=sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010 \
     # via kubernetes
+zict==2.0.0 \
+    --hash=sha256:26aa1adda8250a78dfc6a78d200bfb2ea43a34752cf58980bca75dde0ba0c6e9 \
+    --hash=sha256:8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16 \
+    # via distributed
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "argo-workflows",
         "cattrs<1.1",
         "Click",
+        "dask[distributed]",
         "GitPython",
         "google-cloud-bigquery",
         "google-cloud-bigquery-storage",


### PR DESCRIPTION
Supersedes https://github.com/mozilla/jetstream/pull/299

I ran some benchmarks to see how much speedup this gives us. The actual speedup depends on available CPU resources, but I got up to a 50% speed increase for computation intensive tasks (e.g. the weekly analysis run for `bug-1664289-pref-activity-stream-pocket-new-tab-en-global-feed-release-81-82` and `bug-1665555-pref-etp4-retention-study-release-81-83`).

An even better solution here would be to use [Dask Kubernetes](https://kubernetes.dask.org/en/latest/) which would deploy Dask workers on the cluster instead of just the single pod running the analysis for an experiment. I did try to get this working, however was unable to get the Dask cluster manager working. It's probably worth keeping this option in mind for future improvements though. 