### PR TITLE
Provide options to pass cluster IP and certificate

### DIFF
--- a/jetstream/argo.py
+++ b/jetstream/argo.py
@@ -93,13 +93,19 @@ def get_config(
     cluster_cert: Optional[str] = None,
 ):
     """Get the kubernetes cluster config."""
-    if not cluster_ip or not cluster_cert:
+
+    if not cluster_ip and not cluster_cert:
         cluster_manager_client = ClusterManagerClient()
         cluster = cluster_manager_client.get_cluster(
             name=f"projects/{project_id}/locations/{zone}/clusters/{cluster_id}"
         )
         cluster_ip = cluster.endpoint
         cluster_cert = str(cluster.master_auth.cluster_ca_certificate)
+    elif not (cluster_ip and cluster_cert):
+        raise Exception(
+            "Cluster IP and cluster certificate required when cluster configuration "
+            "is provided explicitly."
+        )
 
     creds, projects = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
 


### PR DESCRIPTION
Used in https://github.com/mozilla/telemetry-airflow/pull/1186

I realized that it might not be possible to grant Compute Engine API access to the Airflow cluster without deleting and creating a new cluster that has the necessary permissions. So this is potentially something data ops might not be willing to do. Fortunately, I also found a workaround. We can pass in the Jetstream Kubernetes cluster IP and certificate used for authenticating to the cluster and don't need Compute Engine API access for this. Both the IP and certificate can be stored as Airflow variables.