### PR TITLE
Fix Experimenter API V6 date parsing

### DIFF
--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -131,7 +131,7 @@ class ExperimentV6:
         converter = cattr.Converter()
         converter.register_structure_hook(
             dt.datetime,
-            lambda num, _: pytz.utc.localize(dt.datetime.strptime(num, "%Y-%m-%d")),
+            lambda num, _: dt.datetime.fromisoformat(num.replace("Z", "+00:00")),
         )
         return converter.structure(d, cls)
 

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -191,7 +191,7 @@ EXPERIMENTER_FIXTURE_V6 = r"""
     "count":100,
     "total":10000 
   },
-  "startDate":"2020-07-29",
+  "startDate":"2020-07-29T20:05:16.271480Z",
   "endDate":null,
   "branches":[{
       "slug":"treatment",
@@ -228,7 +228,7 @@ EXPERIMENTER_FIXTURE_V6 = r"""
       "count":0,
       "total":10000
     },
-    "startDate":"2020-07-28",
+    "startDate":"2020-07-28T20:05:16.271480Z",
     "endDate":null,
     "branches":[{
       "slug":"treatment",


### PR DESCRIPTION
Now that there are V6 experiments, jetstream is throwing the following error:
`'ERROR:2020-11-16 20:38:51,025:jetstream.experimenter:unconverted data remains: T20:05:16.271480Z\n'`

The date format returned by the Experimenter V6 API is something like `2020-07-29T20:05:16.271480Z`