### PR TITLE
Mark experiments without tables as changed when their config updates

### DIFF
--- a/jetstream/external_config.py
+++ b/jetstream/external_config.py
@@ -94,10 +94,12 @@ class ExternalConfigCollection:
         updated_configs = []
 
         for config in self.configs:
+            seen = False
             table_prefix = bq_normalize_name(config.slug)
             for row in result:
                 if not row.table_name.startswith(table_prefix):
                     continue
+                seen = True
                 if not len(row.last_updated):
                     continue
                 table_last_updated = UTC.localize(
@@ -106,5 +108,7 @@ class ExternalConfigCollection:
                 if table_last_updated < config.last_modified:
                     updated_configs.append(config)
                     break
+            if not seen:
+                updated_configs.append(config)
 
         return updated_configs

--- a/jetstream/tests/integration/test_external_config_integration.py
+++ b/jetstream/tests/integration/test_external_config_integration.py
@@ -113,3 +113,15 @@ class TestExternalConfigIntegration:
 
         assert len(updated_configs) == 1
         assert updated_configs[0].slug == config.slug
+
+    def test_new_config_without_a_table_is_marked_changed(
+        self, client, temporary_dataset, project_id
+    ):
+        config = ExternalConfig(
+            slug="my_cool_experiment",
+            spec=self.spec,
+            last_modified=pytz.UTC.localize(datetime.datetime.utcnow()),
+        )
+        config_collection = ExternalConfigCollection([config])
+        updated_configs = config_collection.updated_configs(project_id, temporary_dataset)
+        assert [updated.slug for updated in updated_configs] == ["my_cool_experiment"]

--- a/jetstream/tests/integration/test_external_config_integration.py
+++ b/jetstream/tests/integration/test_external_config_integration.py
@@ -22,17 +22,6 @@ class TestExternalConfigIntegration:
     )
     spec = AnalysisSpec.from_dict(toml.loads(config_str))
 
-    def test_new_config(self, client, project_id, temporary_dataset):
-        config = ExternalConfig(
-            slug="new_experiment",
-            spec=self.spec,
-            last_modified=datetime.datetime.utcnow(),
-        )
-        config_collection = ExternalConfigCollection([config])
-        updated_configs = config_collection.updated_configs(project_id, temporary_dataset)
-
-        assert len(updated_configs) == 0
-
     def test_old_config(self, client, project_id, temporary_dataset):
         config = ExternalConfig(
             slug="new_table",


### PR DESCRIPTION
Currently we aren't rerunning experiments if their configuration changes but they've never been run before.