### PR TITLE
Allow start_date override

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -278,6 +278,7 @@ class Analysis:
 
     def validate(self) -> None:
         self.check_runnable()
+        assert self.config.experiment.start_date is not None  # for mypy
 
         dates_enrollment = self.config.experiment.proposed_enrollment + 1
 
@@ -353,6 +354,7 @@ class Analysis:
         logger.info("Analysis.run invoked for experiment %s", self.config.experiment.normandy_slug)
 
         self.check_runnable(current_date)
+        assert self.config.experiment.start_date is not None  # for mypy
 
         # set up dask
         _dask_cluster = _dask_cluster or LocalCluster(

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -525,11 +525,20 @@ class TestExperimentSpec:
 
 
 class TestExperimentConf:
-    def test_bad_end_date(self, experiments):
+    def test_bad_dates(self, experiments):
         conf = dedent(
             """
             [experiment]
             end_date = "Christmas"
+            """
+        )
+        with pytest.raises(ValueError):
+            config.AnalysisSpec.from_dict(toml.loads(conf))
+
+        conf = dedent(
+            """
+            [experiment]
+            start_date = "My birthday"
             """
         )
         with pytest.raises(ValueError):
@@ -547,6 +556,19 @@ class TestExperimentConf:
         cfg = spec.resolve(live_experiment)
         assert cfg.experiment.end_date == dt.datetime(2020, 12, 31, tzinfo=pytz.utc)
         assert cfg.experiment.status == "Complete"
+
+    def test_good_start_date(self, experiments):
+        conf = dedent(
+            """
+            [experiment]
+            start_date = "2020-12-31"
+            end_date = "2021-02-01"
+            """
+        )
+        spec = config.AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(experiments[0])
+        assert cfg.experiment.start_date == dt.datetime(2020, 12, 31, tzinfo=pytz.utc)
+        assert cfg.experiment.end_date == dt.datetime(2021, 2, 1, tzinfo=pytz.utc)
 
 
 class TestDefaultConfiguration:


### PR DESCRIPTION
For certain experiment designs (e.g. holdbacks), it's useful to lie to Jetstream about when an experiment launched.

We'll use this in https://github.com/mozilla/jetstream-config/pull/20. cc @teonbrooks