### PR TITLE
Don't crash on log-space KDEs

### DIFF
--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import numbers
 import re
 from abc import ABC, abstractmethod
 from decimal import Decimal
@@ -51,7 +52,7 @@ class Summary:
         return self.statistic.apply(data, self.metric.name, experiment)
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, kw_only=True)
 class StatisticResult:
     """
     Represents the resulting data after applying a statistic transformation
@@ -60,15 +61,23 @@ class StatisticResult:
 
     metric: str
     statistic: str
-    parameter: Optional[Decimal] = attr.ib(converter=_maybe_decimal)
     branch: str
+    parameter: Optional[Decimal] = attr.ib(converter=_maybe_decimal, default=None)
     comparison: Optional[str] = None
     comparison_to_branch: Optional[str] = None
-    ci_width: Optional[float] = 0.0
-    point: Optional[float] = 0.0
-    lower: Optional[float] = 0.0
-    upper: Optional[float] = 0.0
+    ci_width: Optional[float] = None
+    point: Optional[float] = None
+    lower: Optional[float] = None
+    upper: Optional[float] = None
     segment: Optional[str] = None
+
+    def __attrs_post_init__(self):
+        for k in ("ci_width", "point", "lower", "upper"):
+            v = getattr(self, k)
+            if v is None:
+                continue
+            if not isinstance(v, numbers.Number):
+                raise ValueError(f"Expected a number for {k}; got {repr(v)}")
 
     bq_schema = (
         bigquery.SchemaField("metric", "STRING"),

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -517,7 +517,7 @@ class KernelDensityEstimate(Statistic):
                         comparison=None,
                         comparison_to_branch=None,
                         ci_width=None,
-                        point=kde.evaluate(0),
+                        point=kde.evaluate(0)[0],
                         lower=None,
                         upper=None,
                     )

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -9,6 +9,7 @@ from jetstream.statistics import (
     Count,
     EmpiricalCDF,
     KernelDensityEstimate,
+    StatisticResult,
     _make_grid,
 )
 
@@ -165,3 +166,9 @@ class TestStatistics:
         assert len(result) > 0
 
         assert stat.name() == "empirical_cdf"
+
+    def test_statistic_result_rejects_invalid_types(self):
+        args = {"metric": "foo", "statistic": "bar", "branch": "baz"}
+        StatisticResult(**args)
+        with pytest.raises(ValueError):
+            StatisticResult(point=[3], **args)

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -146,6 +146,8 @@ class TestStatistics:
         wine.loc[0, "ash"] = 0
         stat = KernelDensityEstimate(log_space=True)
         result = stat.transform(wine, "ash", "*", None).to_dict()["data"]
+        for r in result:
+            assert isinstance(r["point"], float)
         df = pd.DataFrame(result).astype({"parameter": float})
         assert df["parameter"].min() == 0
 


### PR DESCRIPTION
kde.evaluate always returns an ndarray, not a scalar, even when the argument is a scalar.

I assume statsmodels doesn't have type annotations, so mypy didn't catch this.

The error message we got for this crash wasn't great because we didn't notice the error until the BigQuery API tried to serialize the output to JSON and didn't accept the ndarray. Should we make runtime assertions about types when we construct the StatisticsResult?