### PR TITLE
Allow parameters for rerun-config-changed in entrypoint

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -7,7 +7,7 @@ if [ "$1" = "export-statistics-to-json" ]; then
     jetstream export-statistics-to-json "${@:2}"
 elif [ "$1" = "rerun-config-changed" ]; then
     # this is triggered by the jetstream-config repo
-    jetstream rerun-config-changed --argo
+    jetstream rerun-config-changed --argo "${@:2}"
 elif [ "$1" = "run-argo" ]; then
     # argo
     jetstream --log_to_bigquery run-argo "${@:2}"


### PR DESCRIPTION
jetstream-config calls rerun-config-changed via the entrypoint script. Currently, it just ignores all parameters and flags.

See https://github.com/mozilla/jetstream-config/pull/38