### PR TITLE
Fix Argo workflow status extraction

### DIFF
--- a/jetstream/argo.py
+++ b/jetstream/argo.py
@@ -76,7 +76,8 @@ def submit_workflow(
             )
 
             if (
-                workflow["status"]
+                "status" in workflow
+                and workflow["status"]
                 and "finishedAt" in workflow["status"]
                 and workflow["status"]["finishedAt"] is not None
             ):
@@ -88,7 +89,7 @@ def submit_workflow(
 
     # check status of pods
     all_pods_succeeded = True
-    if workflow["status"] and workflow["status"]["nodes"]:
+    if "status" in workflow and workflow["status"] and workflow["status"]["nodes"]:
         all_pods_succeeded = all(
             [
                 node["phase"] == "Succeeded"


### PR DESCRIPTION
Should fix last nights Airflow errors. The run still successfully completed in Argo, but extracting the workflow status caused some problems:

```
[2021-01-06 05:06:09,571] {pod_launcher.py:156} INFO - b'Traceback (most recent call last):\n'
[2021-01-06 05:06:09,571] {pod_launcher.py:156} INFO - b'  File "/usr/local/bin/jetstream", line 8, in <module>\n'
[2021-01-06 05:06:09,571] {pod_launcher.py:156} INFO - b'    sys.exit(cli())\n'
[2021-01-06 05:06:09,571] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    return self.main(*args, **kwargs)\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    rv = self.invoke(ctx)\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    return _process_result(sub_ctx.command.invoke(sub_ctx))\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    return ctx.invoke(self.callback, **ctx.params)\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    return callback(*args, **kwargs)\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/jetstream/cli.py", line 397, in run_argo\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    AnalysisExecutor(\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/jetstream/cli.py", line 225, in execute\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    return strategy.execute(worklist, self.configuration_map)\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/jetstream/cli.py", line 98, in execute\n'
[2021-01-06 05:06:09,572] {pod_launcher.py:156} INFO - b'    return submit_workflow(\n'
[2021-01-06 05:06:09,573] {pod_launcher.py:156} INFO - b'  File "/usr/local/lib/python3.8/site-packages/jetstream/argo.py", line 79, in submit_workflow\n'
[2021-01-06 05:06:09,573] {pod_launcher.py:156} INFO - b'    workflow["status"]\n'
[2021-01-06 05:06:09,573] {pod_launcher.py:156} INFO - b"KeyError: 'status'\n"
```