### PR TITLE
Update CircleCI deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.6.1
+  gcp-gcr: circleci/gcp-gcr@0.11.0
 
 jobs:
   build:
@@ -65,7 +65,7 @@ jobs:
           venv/bin/pytest --black --flake8 --integration jetstream/tests/integration/
 
 workflows:
-  version: 2
+  version: 2.1
   build-and-deploy:
     jobs:
       - build


### PR DESCRIPTION
The `build-and-push-image` CI step is currently failing with:

```
ERROR: (gcloud.config.set) Some requests did not succeed:
 - Required 'compute.zones.list' permission for 'projects/***********************'
```

We actually ran into a very similar issue in telemetry-airflow (same error, but syncing to GCS instead of publishing images), which was fixed in https://github.com/mozilla/telemetry-airflow/pull/1222. Apparently GCP broke something with their latest cloud SDK image. Not sure if this will actually fix the issue, it's hard to test the image publishing step locally. But I guess we should update this anyway at some point.

Edit: This probably won't fix the issue since gcp-gcr downloads the most recent cloud SDK image, which is broken.