### PR TITLE
Don't let tasks fail when custom Jetstream exception is raised

### DIFF
--- a/jetstream/errors.py
+++ b/jetstream/errors.py
@@ -1,28 +1,35 @@
-class NoSlugException(Exception):
+class ValidationException(Exception):
+    """Exception thrown when an experiment is invalid."""
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class NoSlugException(ValidationException):
     def __init__(self, message="Experiment has no slug"):
         super().__init__(message)
 
 
-class NoEnrollmentPeriodException(Exception):
+class NoEnrollmentPeriodException(ValidationException):
     def __init__(self, normandy_slug, message="Experiment has no enrollment period"):
         super().__init__(f"{normandy_slug} -> {message}")
 
 
-class NoStartDateException(Exception):
+class NoStartDateException(ValidationException):
     def __init__(self, normandy_slug, message="Experiment has no start date."):
         super().__init__(f"{normandy_slug} -> {message}")
 
 
-class EndedException(Exception):
+class EndedException(ValidationException):
     def __init__(self, normandy_slug, message="Experiment has already ended."):
         super().__init__(f"{normandy_slug} -> {message}")
 
 
-class EnrollmentLongerThanAnalysisException(Exception):
+class EnrollmentLongerThanAnalysisException(ValidationException):
     def __init__(self, normandy_slug, message="Enrollment period is longer than analysis dates."):
         super().__init__(f"{normandy_slug} -> {message}")
 
 
-class HighPopulationException(Exception):
+class HighPopulationException(ValidationException):
     def __init__(self, normandy_slug, message="Experiment has high population."):
         super().__init__(f"{normandy_slug} -> {message}")


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/454

Currently, if Jetstream raises one of [its custom exceptions](https://github.com/mozilla/jetstream/blob/main/jetstream/errors.py) Argo will retry the task several times even though none of the retries will ever succeed. This results in some scary looking graphs in Argo although nothing bad is actually happening. If there was, we'd get an alert.

![Screen Shot 2021-02-22 at 10 47 59](https://user-images.githubusercontent.com/1239705/108754948-785e6e80-74fb-11eb-8d28-b88213423b28.png)

So to prevent Argo from retrying, this PR will change Jetstream's behaviour to return a success state when a task raises a custom `JetstreamException`. 

This will potentially reduce the time Jetstream requires to complete it's daily analysis and reduce the number of pods Kubernetes spawns. One downside is that looking at the Argo interface it will not be immediately apparent if a task succeeded because the analysis completed successfully or because there was a `JetstreamException`. I usually use the Redash dashboard to check which analyses failed instead of the Argo interface, so this might be okay.

We can also ignore `JetstreamException` when rerunning the analyses via jetstream-config since the `validate` CI step will flag issues such as `NoStartDateException` or `NoEnrollmentPeriodException`.
