### PR TITLE
Support data_sources with no experiments column

### DIFF
--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -95,23 +95,37 @@ class TestAnalysisSpec:
         config_str = dedent(
             """
             [metrics]
-            weekly = ["spam"]
+            weekly = ["spam", "taunts"]
             [metrics.spam]
             data_source = "eggs"
             select_expression = "1"
             [metrics.spam.statistics.bootstrap_mean]
 
+            [metrics.taunts]
+            data_source = "silly_knight"
+            select_expression = "1"
+            [metrics.taunts.statistics.bootstrap_mean]
+
             [data_sources.eggs]
             from_expression = "england.camelot"
             client_id_column = "client_info.client_id"
+
+            [data_sources.silly_knight]
+            from_expression = "france"
+            experiments_column_type = "none"
             """
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
         spam = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][0].metric
+        taunts = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "taunts"][
+            0
+        ].metric
         assert spam.data_source.name == "eggs"
         assert "camelot" in spam.data_source._from_expr
         assert "client_info" in spam.data_source.client_id_column
+        assert spam.data_source.experiments_column_type == "simple"
+        assert taunts.data_source.experiments_column_type is None
 
     def test_definitions_override_other_metrics(self, experiments):
         """Test that config definitions override mozanalysis definitions.


### PR DESCRIPTION
@SuYoungHong pointed out that we don't support data sources without an experiments column in jetstream-config because mozanalysis expects an explicit `None` value and TOML can't encode it.