### PR TITLE
Run metrics queries in shared-prod

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -202,7 +202,37 @@ class Analysis:
                 enrollments_table,
             )
 
-            self.bigquery.execute(metrics_sql, res_table_name)
+            if "main" in metrics_sql:
+                # todo: remove/undo
+                # Run metrics queries in shared-prod as a workaround
+                shared_prod_client = BigQueryClient(
+                    project="moz-fx-data-shared-prod", dataset="tmp"
+                )
+
+                tmp_enrollments_table = f"moz-fx-data-shared-prod.tmp.{enrollments_table}"
+                job_config = bigquery.CopyJobConfig()
+                job_config.write_disposition = "WRITE_TRUNCATE"
+
+                shared_prod_client.client.copy_table(
+                    f"{self.project}.{self.dataset}.{enrollments_table}",
+                    tmp_enrollments_table,
+                    job_config=job_config,
+                ).result()
+
+                metrics_sql = metrics_sql.replace(enrollments_table, tmp_enrollments_table)
+
+                tmp_metrics_table = f"moz-fx-data-shared-prod.tmp.{res_table_name}"
+                shared_prod_client.execute(metrics_sql, res_table_name)
+
+                shared_prod_client.client.copy_table(
+                    tmp_metrics_table,
+                    f"{self.project}.{self.dataset}.{res_table_name}",
+                    job_config=job_config,
+                ).result()
+
+            else:
+                self.bigquery.execute(metrics_sql, res_table_name)
+
             self._publish_view(period)
 
         return res_table_name


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/550

Since we still want the result in `moz-fx-data-experiments` simply changing the project ID to shared prod would mean that all result tables are written to `mozanalysis` in shared-prod. Instead a temporary workaround is to just run the metrics query in shared prod and copy the result tables around. Once the BigQuery issues are resolved we can undo the changes here.