### PR TITLE
Fix Fenix experiment analysis

### DIFF
--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -139,10 +139,19 @@ class ExperimentV6:
 
     @classmethod
     def from_dict(cls, d) -> "ExperimentV6":
-        converter = cattr.Converter()
+        converter = cattr.GenConverter()
         converter.register_structure_hook(
             dt.datetime,
             lambda num, _: dt.datetime.fromisoformat(num.replace("Z", "+00:00")),
+        )
+        converter.register_structure_hook(
+            cls,
+            cattr.gen.make_dict_structure_fn(
+                cls,
+                converter,
+                _appName=cattr.override(rename="appName"),
+                _appId=cattr.override(rename="appId"),
+            ),
         )
         return converter.structure(d, cls)
 

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -269,6 +269,48 @@ EXPERIMENTER_FIXTURE_V6 = r"""
 ]
 """  # noqa
 
+FENIX_EXPERIMENT_FIXTURE = """
+{
+  "schemaVersion": "1.4.0",
+  "slug": "fenix-bookmark-list-icon",
+  "id": "fenix-bookmark-list-icon",
+  "arguments": {},
+  "application": "org.mozilla.fenix",
+  "appName": "fenix",
+  "appId": "org.mozilla.fenix",
+  "channel": "nightly",
+  "userFacingName": "Fenix Bookmark List Icon",
+  "userFacingDescription": "If we make the save-bookmark and access-bookmarks icons more visually distinct,  users are more likely to know what icon to click to save their bookmarks. By changing the access-bookmarks icon, we believe that we will and can see an increase in engagement with the save to bookmarks icon.",
+  "isEnrollmentPaused": true,
+  "bucketConfig": {
+    "randomizationUnit": "nimbus_id",
+    "namespace": "fenix-bookmark-list-icon-1",
+    "start": 0,
+    "count": 10000,
+    "total": 10000
+  },
+  "probeSets": [],
+  "outcomes": [],
+  "branches": [
+    {
+      "slug": "control",
+      "ratio": 1
+    },
+    {
+      "slug": "treatment",
+      "ratio": 1
+    }
+  ],
+  "targeting": "true",
+  "startDate": "2021-02-09T19:36:51.667812Z",
+  "endDate": "2021-03-11T12:53:30.039190Z",
+  "proposedDuration": 28,
+  "proposedEnrollment": 7,
+  "referenceBranch": "control",
+  "featureIds": []
+}
+"""  # noqa:E501
+
 
 @pytest.fixture
 def mock_session():
@@ -433,3 +475,8 @@ def test_experiment_v6_status():
     )
 
     assert experiment_complete.to_experiment().status == "Complete"
+
+
+def test_app_name():
+    x = ExperimentV6.from_dict(json.loads(FENIX_EXPERIMENT_FIXTURE))
+    assert x.appName == "fenix"

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -480,3 +480,4 @@ def test_experiment_v6_status():
 def test_app_name():
     x = ExperimentV6.from_dict(json.loads(FENIX_EXPERIMENT_FIXTURE))
     assert x.appName == "fenix"
+    assert x.appId == "org.mozilla.fenix"


### PR DESCRIPTION
I misunderstood how cattrs and attrs interacted with respect to _prefixed attributes.

attrs expects the attributes to appear in the constructor without a prefix. cattrs expects the attributes to appear in the dictionary with a prefix!

```python
>>> import cattr
>>> import attr
>>> @attr.s(auto_attribs=True)
... class A:
...   _foo: str
...
>>> A(foo="bar")
A(_foo='bar')
>>> cattr.structure({"_foo": "bar"}, A)
A(_foo='bar')
>>> cattr.structure({"foo": "bar"}, A)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tsmith/projects/jetstream/venv/lib/python3.9/site-packages/cattr/converters.py", line 205, in structure
    return self._structure_func.dispatch(cl)(obj, cl)
  File "/Users/tsmith/projects/jetstream/venv/lib/python3.9/site-packages/cattr/converters.py", line 345, in structure_attrs_fromdict
    return cl(**conv_obj)  # type: ignore
TypeError: __init__() missing 1 required positional argument: 'foo'
```

This was causing us to fallback to firefox-desktop in the property accessors, which meant that the experiment was treated by mozanalysis as a desktop experiment, which meant we didn't observe any enrollments!

This fix is suggested at https://github.com/Tinche/cattrs/issues/23#issuecomment-776655547.