### PR TITLE
Fix argo status check of failed pods

### DIFF
--- a/jetstream/argo.py
+++ b/jetstream/argo.py
@@ -90,7 +90,7 @@ def submit_workflow(
 
     # check status of pods
     if "status" in workflow and workflow["status"] and workflow["status"]["nodes"]:
-        pods_succeeded = [
+        pods_succeeded = {
             # name contains the step name and all parameter values, e.g.
             # jetstream-zvbcs[0].ensure-enrollments-and-analyze(0:dates:[\"2021-03-25\"],
             # slug:set-default-as-first-screen-100-roll-out)[1].analyse-and-export(0:2021-03-25)
@@ -99,7 +99,7 @@ def submit_workflow(
             re.sub(r"\(\d\)", "", node["name"])  # remove retry number
             for _, node in workflow["status"]["nodes"].items()
             if node["type"] == "Pod" and node["phase"] == "Succeeded"
-        ]
+        }
 
         pods_failed = [
             node["name"]


### PR DESCRIPTION
We had a bunch of jetstream-config failures which made me aware of this problem: jetstream was checking the status of each pod but didn't take into account that argo might do a successful retry. So whenever a step failed, jetstream returned a failed status code, although the step did succeed in a retry.