### PR TITLE
Skip experiments early

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -301,7 +301,18 @@ class AnalysisExecutor:
 
             run_configs = self._experiments_to_configs(existing_experiments, config_getter)
 
-        return run_configs
+        # filter out experiments that are always getting skipped
+        non_skipped_configs = []
+        for c in run_configs:
+            if not c.experiment.skip:
+                non_skipped_configs.append(c)
+            else:
+                logger.warning(
+                    f"Skipping {c.experiment.normandy_slug}; skip=true in config.",
+                    extra={"experiment": c.experiment.normandy_slug},
+                )
+
+        return non_skipped_configs
 
     def ensure_enrollments(
         self,


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/577

For experiments that are marked as `skip=true` in the config, Jetstream currently always includes them in the worklist of experiments to be analyzed. Every time, pods are created that result in the `SkippedException` being thrown. 

This is especially problematic when rerunning experiments with changed configs. Since no table will ever be created for skipped experiments, Jetstream always thinks the config has changed and tries to rerun the experiments. This does create a lot of pods that do nothing else but raise `SkippedException`.

To make reruns complete faster, this change will ignore these experiments in the first place.

Depends on https://github.com/mozilla/jetstream/pull/599