### PR TITLE
Tox should test with pins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py38, py38-mypy
 
 [testenv]
-extras = testing
+deps = -rrequirements.txt
 commands =
   flake8 jetstream
   black --check jetstream


### PR DESCRIPTION
Create an environment using pins and not the latest package versions du jour.