### PR TITLE
Dask logging

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -20,6 +20,7 @@ import jetstream.errors as errors
 from jetstream.bigquery_client import BigQueryClient
 from jetstream.config import AnalysisConfiguration
 from jetstream.dryrun import dry_run_query
+from jetstream.logging import LogConfiguration
 from jetstream.statistics import (
     Count,
     StatisticResult,
@@ -44,6 +45,7 @@ class Analysis:
     project: str
     dataset: str
     config: AnalysisConfiguration
+    log_config: Optional[LogConfiguration] = None
 
     @property
     def bigquery(self):
@@ -409,6 +411,11 @@ class Analysis:
 
         # prepare dask tasks
         results = []
+
+        if self.log_config:
+            setup_logger = dask.delayed(self.log_config.setup_logger)
+            results.append(setup_logger)
+
         table_to_dataframe = dask.delayed(self.bigquery.table_to_dataframe)
 
         for period in self.config.metrics:

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -20,7 +20,7 @@ import jetstream.errors as errors
 from jetstream.bigquery_client import BigQueryClient
 from jetstream.config import AnalysisConfiguration
 from jetstream.dryrun import dry_run_query
-from jetstream.logging import LogConfiguration
+from jetstream.logging import LogConfiguration, LogPlugin
 from jetstream.statistics import (
     Count,
     StatisticResult,
@@ -413,8 +413,8 @@ class Analysis:
         results = []
 
         if self.log_config:
-            setup_logger = dask.delayed(self.log_config.setup_logger)
-            results.append(setup_logger)
+            log_plugin = LogPlugin(self.log_config)
+            client.register_worker_plugin(log_plugin)
 
         table_to_dataframe = dask.delayed(self.bigquery.table_to_dataframe)
 

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -38,7 +38,6 @@ from .logging import LogConfiguration
 from .metadata import export_metadata
 from .util import inclusive_date_range
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/jetstream/logging/__init__.py
+++ b/jetstream/logging/__init__.py
@@ -1,0 +1,31 @@
+import attr
+import logging
+
+from typing import Optional
+
+from .bigquery_log_handler import BigQueryLogHandler
+
+
+@attr.s(auto_attribs=True)
+class LogConfiguration:
+    """Configuration for setting up logging."""
+
+    log_project_id: Optional[str]
+    log_dataset_id: Optional[str]
+    log_table_id: Optional[str]
+    log_to_bigquery: bool = False
+    capacity: int = 50
+
+    def setup_logger(self, client=None):
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(levelname)s:%(asctime)s:%(name)s:%(message)s",
+        )
+        logger = logging.getLogger()
+
+        if self.log_to_bigquery:
+            bigquery_handler = BigQueryLogHandler(
+                self.log_project_id, self.log_dataset_id, self.log_table_id, client, self.capacity
+            )
+            bigquery_handler.setLevel(logging.WARNING)
+            logger.addHandler(bigquery_handler)

--- a/jetstream/logging/__init__.py
+++ b/jetstream/logging/__init__.py
@@ -1,7 +1,9 @@
-import attr
 import logging
-
 from typing import Optional
+
+import attr
+import dask.distributed
+from distributed.diagnostics.plugin import WorkerPlugin
 
 from .bigquery_log_handler import BigQueryLogHandler
 
@@ -29,3 +31,17 @@ class LogConfiguration:
             )
             bigquery_handler.setLevel(logging.WARNING)
             logger.addHandler(bigquery_handler)
+
+
+class LogPlugin(WorkerPlugin):
+    """
+    Dask worker plugin for initializing the logger.
+
+    This ensures that the BigQuery logging handler gets initialized.
+    """
+
+    def __init__(self, log_config: LogConfiguration):
+        self.log_config = log_config
+
+    def setup(self, _worker: dask.distributed.Worker):
+        self.log_config.setup_logger()

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -172,7 +172,8 @@ class Statistic(ABC):
                         ).data
                     except Exception as e:
                         logger.error(
-                            f"Error while computing statistic {self.name} for metric {metric}: {e}",
+                            f"Error while computing statistic {self.name()} "
+                            + f"for metric {metric}: {e}",
                             extra={"experiment": experiment.normandy_slug},
                         )
 

--- a/jetstream/tests/integration/test_logging_integration.py
+++ b/jetstream/tests/integration/test_logging_integration.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from google.cloud import bigquery
 
-from jetstream.cli import setup_logger
+from jetstream.logging import LogConfiguration
 
 
 class TestLoggingIntegration:
@@ -23,7 +23,10 @@ class TestLoggingIntegration:
         table = bigquery.Table(f"{project_id}.{temporary_dataset}.logs", schema=schema)
         table = client.client.create_table(table)
 
-        setup_logger(project_id, temporary_dataset, "logs", log_to_bigquery=True, capacity=1)
+        log_config = LogConfiguration(
+            project_id, temporary_dataset, "logs", log_to_bigquery=True, capacity=1
+        )
+        log_config.setup_logger()
 
         yield
         client.client.delete_table(table, not_found_ok=True)

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -420,7 +420,7 @@ class TestSerialExecutorStrategy:
         config = spec.resolve(experiment)
         run_date = dt.datetime(2020, 10, 31, tzinfo=UTC)
         strategy.execute([(config, run_date)])
-        fake_analysis.assert_called_once_with("spam", "eggs", config)
+        fake_analysis.assert_called_once_with("spam", "eggs", config, None)
         fake_analysis().run.assert_called_once_with(run_date)
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -38,7 +38,7 @@ coverage==5.5
     # via
     #   mozilla-jetstream
     #   pytest-cov
-dask[distributed]==2021.05.1
+dask==2021.05.1
     # via
     #   distributed
     #   mozilla-jetstream
@@ -52,7 +52,7 @@ gitdb==4.0.7
     # via gitpython
 gitpython==3.1.17
     # via mozilla-jetstream
-google-api-core[grpc]==1.28.0
+google-api-core[grpc]==1.29.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
@@ -67,7 +67,7 @@ google-cloud-bigquery-storage==2.4.0
     # via
     #   mozanalysis
     #   mozilla-jetstream
-google-cloud-bigquery==2.17.0
+google-cloud-bigquery==2.18.0
     # via
     #   mozanalysis
     #   mozilla-jetstream
@@ -164,7 +164,7 @@ proto-plus==1.18.1
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-container
-protobuf==3.17.1
+protobuf==3.17.2
     # via
     #   google-api-core
     #   google-cloud-bigquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -170,7 +170,7 @@ coverage==5.5 \
     # via
     #   -r requirements.in
     #   pytest-cov
-dask[distributed]==2021.05.1 \
+dask==2021.05.1 \
     --hash=sha256:4f2a0f67cc99ca511cefa0a7d383870807776a17c26a8da788dafb68ab552079 \
     --hash=sha256:b24620e64dc978fe0df069143a10c7093c72fcb9e837644b8845a2ffaa10e1ce
     # via
@@ -179,9 +179,7 @@ dask[distributed]==2021.05.1 \
 distributed==2021.05.1 \
     --hash=sha256:e8e120480b0a45e3804136f7f9e17ea6f84f58c8f0b11d84dca2ea9c81c015aa \
     --hash=sha256:f3b3d2091cf899658ae01f4fbc443ba86520ccdce8be64ce6087fcf48dbf50df
-    # via
-    #   -r requirements.in
-    #   dask
+    # via -r requirements.in
 flake8==3.9.2 \
     --hash=sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b \
     --hash=sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907
@@ -204,9 +202,9 @@ gitpython==3.1.17 \
     --hash=sha256:29fe82050709760081f588dd50ce83504feddbebdc4da6956d02351552b1c135 \
     --hash=sha256:ee24bdc93dce357630764db659edaf6b8d664d4ff5447ccfeedd2dc5c253f41e
     # via -r requirements.in
-google-api-core[grpc]==1.28.0 \
-    --hash=sha256:02646803bd728e12dd1f45ee1dcc31c12614c9a1ac451b9a1ce26aa65df9b957 \
-    --hash=sha256:a658a4e367511a444c7daf2c58855ff6fd7f7d138c154e5b17186c1f8154c8cb
+google-api-core[grpc]==1.29.0 \
+    --hash=sha256:dbe885011111a9afd9ea9a347db6a9c608e82e5c7648c1f7fabf2b4079a579b5 \
+    --hash=sha256:f83118319d2a28806ec3399671cbe4af5351bd0dac54c40a0395da6162ebe324
     # via
     #   -r requirements.in
     #   google-cloud-bigquery
@@ -227,9 +225,9 @@ google-cloud-bigquery-storage==2.4.0 \
     # via
     #   -r requirements.in
     #   mozanalysis
-google-cloud-bigquery==2.17.0 \
-    --hash=sha256:88ed16b2a5761ad2eebd4a6e23f7f022630291c92410c123b04f77bbda9ad469 \
-    --hash=sha256:922d8ed28262793b6a9d23e10ffc785963f3e574686c77a3ed57c93acdc42200
+google-cloud-bigquery==2.18.0 \
+    --hash=sha256:d092f259f40a37b9189d75bf0d1269dd91fe11eb0bbfbfc25c93e6c5762d6f83 \
+    --hash=sha256:ecfc6aec99da83662126285a08c0802d104553552a489d8c46e9ca9eb8228bfb
     # via
     #   -r requirements.in
     #   mozanalysis
@@ -609,30 +607,30 @@ proto-plus==1.18.1 \
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-container
-protobuf==3.17.1 \
-    --hash=sha256:0f237c1e84e46747397a3e8173edb3116e81163b2878fc944a5193b05876eaee \
-    --hash=sha256:1fcace96670b8512e805d6e275bd59b860967a7648e05cfad35ec1e7c03d7262 \
-    --hash=sha256:25bc4f1c23aced9b3a9e70eef7f03e63bcbd6cfbd881a91b5688412dce8992e1 \
-    --hash=sha256:27c7c933b838a0837eb1f429e7994310ee8577a7b69abc38e84d5db97a2650a2 \
-    --hash=sha256:2a88be54fce118d69f083b847554afd1852053c0869bdac396678ec9ec6a94d5 \
-    --hash=sha256:2c6ad26f079301bcf9f1b5d5b4b2dbac0e2e7c0111c6fbecf94f558952c78ee0 \
-    --hash=sha256:36d306dda3c159a5fe0025ba0e9728aac00dd69523dd12ee3fb7b1717cd80e7d \
-    --hash=sha256:40bf764b63f06a816b1c079f7718184fdd8dbfd9dad3cd1a446382492ca00b3e \
-    --hash=sha256:437d4681160ac5310457c4dc8ab973ec56769a236c479393c53fa71a26dfb38f \
-    --hash=sha256:4ef4865ee740d5b45adfc96481adf1fcbfbb454bd51b86f4c4a5065262d0b08b \
-    --hash=sha256:5057744a363d65d2780dc01fa751bb14e860c507b2598b22af241aabb28a0ae9 \
-    --hash=sha256:6e48c9b26d8e262331c79b208c4bf6b499a71912b1213d77b63c5ca248fc2a4e \
-    --hash=sha256:762faa8873d0569466cf66128bdbadd5e500600bdf2f87cf039493ed9d2725b6 \
-    --hash=sha256:8a509097ba25452c9b44198843b0df67f921bd36f37adcbcfaaf6ee5cbe09132 \
-    --hash=sha256:94be4d5c2ba372ff159b2cc804d274acbaa7ebf361966f5619f99880c7c09a3c \
-    --hash=sha256:a15898d88307dba0363767b30960396a2dec74b8ffe7bcb4e885312a569eda3f \
-    --hash=sha256:ad17d3dd80f3377fc70a9dd677ec51231a892f9f65783cf7d2d24ee381f0feca \
-    --hash=sha256:ad8cdbc594c886483970ac274b5af98483b272e873b7c5dac60aa3a7222301b3 \
-    --hash=sha256:b92f95994ff27a6992ea2cf3f369476ad0065986eb00252b760d0bc55c5454a8 \
-    --hash=sha256:c1631570af7aae611f1cd7c6918fe4a7154507169ef30e8c5f380eba36ee2659 \
-    --hash=sha256:cbd132f0aa7180f099d3c47fecfbcdca1590ef3b7da8346146192ba580c9b24e \
-    --hash=sha256:d06ef0f7873e04e2d1a2bfa0701d063e4dde5242b2946c6f071a442e4cb3be0b \
-    --hash=sha256:fea786428b34385b073ef619d896282889b432b87dc043c0b815c72d35d64025
+protobuf==3.17.2 \
+    --hash=sha256:0b5a73fa43efda0df0191c162680ec40cef45463fa8ff69fbeaeeddda4c760f5 \
+    --hash=sha256:1e08da38d56b74962d9cb05d86ca5f25d2e5b78f05fd00db7900cad3faa6de00 \
+    --hash=sha256:38b2c6e2204731cfebdb2452ffb7addf0367172b35cff8ccda338ccea9e7c87a \
+    --hash=sha256:42239d47f213f1ce12ddca62c0c70856efbac09797d715e5d606b3fbc3f16c44 \
+    --hash=sha256:45cc0197e9f9192693c8a4dbcba8c9227a53a2720fc3826dfe791113d9ff5e5e \
+    --hash=sha256:4da073b6c1a83e4ff1294156844f21343c5094e295c194d8ecc94703c7a6f42a \
+    --hash=sha256:4e62be28dcaab52c7e8e8e3fb9a7005dec6374e698f3b22d79276d95c13151e5 \
+    --hash=sha256:50c657a54592c1bec7b24521fdbbbd2f7b51325ba23ab505ed03e8ebf3a5aeff \
+    --hash=sha256:557e16884d7276caf92c1fb188fe6dfbec47891d3507d4982db1e3d89ffd22de \
+    --hash=sha256:5a3450acf046716e4a4f02a3f7adfb7b86f1b5b3ae392cec759915e79538d40d \
+    --hash=sha256:6388e7f300010ea7ac77113c7491c5622645d2447fdf701cbfe026b832d728cd \
+    --hash=sha256:744f5c9a3b9e7538c4c70f2b0e46f86858b684f5d17bf78643a19a6c21c7936f \
+    --hash=sha256:751d71dc6559dd794d309811d8dcf179d6a128b38a1655ae7137530f33895cb4 \
+    --hash=sha256:816fe5e8b73c29adb13a57e1653da15f24cbb90e86ea92e6f08abe6d8c0cbdb4 \
+    --hash=sha256:89613ec119fdcad992f65d7a5bfe3170c17edc839982d0089fc0c9242fb8e517 \
+    --hash=sha256:993814b0199f22523a227696a8e20d2cd4b9cda60c76d2fb3969ce0c77eb9e0f \
+    --hash=sha256:9dc01ddc3b195c4538942790c4b195cf17b52d3785a60c1f6f25b794f51e2071 \
+    --hash=sha256:b667ddbb77ff619fdbd18be75445d4448ee68493c9bddd1b4d0b177025e2f6f6 \
+    --hash=sha256:c2038dec269b65683f16057886c09ca7526471793029bdd43259282e1e0fb668 \
+    --hash=sha256:c303ce92c60d069237cfbd41790fde3d00066ca9500fac464454e20c2f12250c \
+    --hash=sha256:c49e673436e24e925022c090a98905cfe88d056cb5dde67a8e20ae339acd8140 \
+    --hash=sha256:c5b512c1982f8b427a302db094cf79f8f235284014d01b23fba461aa2c1459a0 \
+    --hash=sha256:f3f057ad59cd4d5ea2b1bb88d36c6f009b8043007cf03d96cbd3b9c06859d4fa
     # via
     #   -r requirements.in
     #   google-api-core


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/716

This is more complicated than I initially thought. It appears that the registered `BigQueryLogHandler`s get wiped and aren't actually registered to the `logger`s in the dask workers. This explains why we see the logs in the console but not in BigQuery. This also seems to be related to this issue: https://github.com/dask/distributed/issues/2592

As a workaround, we need to register the `BigQueryLogHandler` when dask workers get set up. This is relatively easily possible by writing a dask [WorkerPlugin](https://docs.dask.org/en/latest/setup/custom-startup.html#worker-lifecycle-plugins)