### PR TITLE
Avoid format string error

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -465,7 +465,9 @@ class Analysis:
         time_limits = self._get_timelimits_if_ready(AnalysisPeriod.DAY, current_date)
 
         if time_limits is None:
-            logger.info("Skipping %s (%s); not ready", self.config.experiment.normandy_slug)
+            logger.info(
+                "Skipping enrollments for %s; not ready", self.config.experiment.normandy_slug
+            )
             return
 
         if self.config.experiment.start_date is None:


### PR DESCRIPTION
This looks harmless; it just prints a warning when we trip it, but we may as well fix it.