### PR TITLE
Fix dask logging plugin setup

### DIFF
--- a/jetstream/logging/__init__.py
+++ b/jetstream/logging/__init__.py
@@ -43,5 +43,5 @@ class LogPlugin(WorkerPlugin):
     def __init__(self, log_config: LogConfiguration):
         self.log_config = log_config
 
-    def setup(self, _worker: dask.distributed.Worker):
+    def setup(self, worker: dask.distributed.Worker):
         self.log_config.setup_logger()


### PR DESCRIPTION
I'll rerun the failed experiments once this is merged

Error was: ` setup() got an unexpected keyword argument 'worker'` 