### PR TITLE
Allow configuration of default metrics in outcomes

### DIFF
--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -795,6 +795,7 @@ class OutcomeSpec:
     friendly_name: str
     description: str
     metrics: Dict[str, MetricDefinition] = attr.Factory(dict)
+    default_metrics: Optional[List[MetricReference]] = attr.ib(None)
     data_sources: DataSourcesSpec = attr.Factory(DataSourcesSpec)
 
     @classmethod
@@ -807,4 +808,13 @@ class OutcomeSpec:
             k: _converter.structure({"name": k, **v}, MetricDefinition)
             for k, v in d.get("metrics", {}).items()
         }
+        params["default_metrics"] = [
+            _converter.structure(m, MetricReference) for m in d.get("default_metrics", [])
+        ]
+
+        # check that default metrics are actually defined in outcome
+        for default_metric in params["default_metrics"]:
+            if default_metric.name not in params["metrics"].keys():
+                raise ValueError(f"Default metric {default_metric} is not defined in outcome.")
+
         return cls(**params)

--- a/jetstream/metadata.py
+++ b/jetstream/metadata.py
@@ -27,6 +27,7 @@ class OutcomeMetadata:
     friendly_name: str
     description: str
     metrics: List[str]
+    default_metrics: List[str]
     commit_hash: Optional[str]
 
 
@@ -60,6 +61,9 @@ class ExperimentMetadata:
                 friendly_name=external_outcome.spec.friendly_name,
                 description=external_outcome.spec.description,
                 metrics=[m for m, _ in external_outcome.spec.metrics.items()],
+                default_metrics=[m.name for m in external_outcome.spec.default_metrics]
+                if external_outcome.spec.default_metrics
+                else [],
                 commit_hash=external_outcome.commit_hash,
             )
             for experiment_outcome in config.experiment.outcomes

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -175,6 +175,7 @@ def fake_outcome_resolver(monkeypatch):
         """
         friendly_name = "Performance outcomes"
         description = "Outcomes related to performance"
+        default_metrics = ["speed"]
 
         [metrics.speed]
         data_source = "main"

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -707,6 +707,7 @@ class TestOutcomes:
             """
             friendly_name = "Test outcome"
             description = "Outcome for testing"
+            default_metrics = ["spam", "organic_search_count"]
 
             [metrics.spam]
             data_source = "main"
@@ -718,6 +719,8 @@ class TestOutcomes:
 
             [metrics.organic_search_count.statistics.bootstrap_mean]
 
+            [metrics.ad_clicks.statistics.bootstrap_mean]
+
             [data_sources.eggs]
             from_expression = "england.camelot"
             client_id_column = "client_info.client_id"
@@ -727,7 +730,27 @@ class TestOutcomes:
         outcome_spec = config.OutcomeSpec.from_dict(toml.loads(config_str))
         assert "spam" in outcome_spec.metrics
         assert "organic_search_count" in outcome_spec.metrics
+        assert "ad_clicks" in outcome_spec.metrics
         assert "eggs" in outcome_spec.data_sources.definitions
+
+        default_metrics = [m.name for m in outcome_spec.default_metrics]
+        assert "spam" in default_metrics
+        assert "organic_search_count" in default_metrics
+        assert "ad_clicks" not in default_metrics
+
+    def test_invalid_default_metrics(self):
+        config_str = dedent(
+            """
+            friendly_name = "Test outcome"
+            description = "Outcome for testing"
+            default_metrics = ["spam"]
+
+            [metrics.ad_clicks.statistics.bootstrap_mean]
+            """
+        )
+
+        with pytest.raises(ValueError):
+            config.OutcomeSpec.from_dict(toml.loads(config_str))
 
     def test_resolving_outcomes(self, experiments, fake_outcome_resolver):
         config_str = dedent(

--- a/jetstream/tests/test_metadata.py
+++ b/jetstream/tests/test_metadata.py
@@ -67,8 +67,10 @@ def test_metadata_with_outcomes(experiments, fake_outcome_resolver):
 
     assert "tastiness" in metadata.outcomes
     assert "performance" in metadata.outcomes
+    assert "speed" in metadata.outcomes["performance"].default_metrics
     assert metadata.outcomes["tastiness"].friendly_name == "Tastiness outcomes"
     assert "meals_eaten" in metadata.outcomes["tastiness"].metrics
+    assert metadata.outcomes["tastiness"].default_metrics == []
 
 
 @patch.object(requests.Session, "get")


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/820

When writing the outcome configs, a list of `default_metrics` can be defined at the top like:

```yaml
    friendly_name = "Test outcome"
    description = "Outcome for testing"
    default_metrics = ["spam", "organic_search_count"]

    [metrics.spam]
    data_source = "main"
    select_expression = "1"

    [metrics.spam.statistics.bootstrap_mean]

    [metrics.organic_search_count.statistics.bootstrap_mean]
    [metrics.ad_clicks.statistics.bootstrap_mean]
```

The exported metadata will then have the list of `default_metrics` for outcomes.

I also opened a PR to updated the docs: https://github.com/mozilla/experimenter-docs/pull/103