### PR TITLE
Add reference_branch to experiment metadata

### DIFF
--- a/jetstream/metadata.py
+++ b/jetstream/metadata.py
@@ -35,6 +35,7 @@ class OutcomeMetadata:
 class ExperimentMetadata:
     metrics: Dict[str, MetricsMetadata]
     outcomes: Dict[str, OutcomeMetadata]
+    reference_branch: Optional[str]
     schema_version: int = StatisticResult.SCHEMA_VERSION
 
     @classmethod
@@ -71,7 +72,11 @@ class ExperimentMetadata:
             if external_outcome.slug == experiment_outcome
         }
 
-        return cls(metrics=metrics_metadata, outcomes=outcomes_metadata)
+        return cls(
+            metrics=metrics_metadata,
+            outcomes=outcomes_metadata,
+            reference_branch=config.experiment.reference_branch,
+        )
 
 
 def export_metadata(config: AnalysisConfiguration, bucket_name: str, project_id: str):

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -61,7 +61,7 @@ class StatisticResult:
     to metric data.
     """
 
-    SCHEMA_VERSION = 2
+    SCHEMA_VERSION = 3
 
     metric: str
     statistic: str


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/840

Adds a new `reference_branch` attribute to the experiment metadata:

```json
{
            "metrics": {
                "view_about_logins": {
                    "friendly_name": "about:logins viewers",
                    "description": "Counts the number of clients that viewed about:logins.\n",
                    "bigger_is_better": true,
                    "analysis_bases": ["enrollments"]
                },
                "my_cool_metric": {
                    "friendly_name": "",
                    "description": "",
                    "bigger_is_better": true,
                    "analysis_bases": ["enrollments"]
                }
            },
            "outcomes": {},
            "reference_branch": "b",   // <--- This got added
            "schema_version": 3         // <--- Bumped the version to 3
}
```

