### PR TITLE
External config metadata

### DIFF
--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -319,6 +319,15 @@ class ExperimentConfiguration:
     def exposure_signal(self) -> Optional[mozanalysis.exposure.ExposureSignal]:
         return self.experiment_spec.exposure_signal
 
+    def has_external_config_overrides(self) -> bool:
+        """Check whether the external config overrides Experimenter configuration."""
+        return (
+            self.reference_branch != self.experimenter_experiment.reference_branch
+            or self.start_date != self.experimenter_experiment.start_date
+            or self.end_date != self.experimenter_experiment.end_date
+            or self.proposed_enrollment != self.experimenter_experiment.proposed_enrollment
+        )
+
     # see https://stackoverflow.com/questions/50888391/pickle-of-object-with-getattr-method-in-
     # python-returns-typeerror-object-no
     def __getstate__(self):

--- a/jetstream/metadata.py
+++ b/jetstream/metadata.py
@@ -1,8 +1,7 @@
 import datetime as dt
-from jetstream.external_config import ExternalConfigCollection
 import json
 import logging
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import attr
 import cattr
@@ -10,6 +9,7 @@ import google.cloud.storage as storage
 
 from jetstream import bq_normalize_name, outcomes
 from jetstream.config import AnalysisConfiguration
+from jetstream.external_config import ExternalConfigCollection
 from jetstream.statistics import StatisticResult
 
 logger = logging.getLogger(__name__)
@@ -133,6 +133,9 @@ def export_metadata(config: AnalysisConfiguration, bucket_name: str, project_id:
     logger.info(f"Uploading {target_file} to {bucket_name}/{target_path}.")
 
     converter = cattr.Converter()
+    _datetime_to_json: Callable[[dt.datetime], str] = lambda dt: dt.strftime("%Y-%m-%d")
+    converter.register_unstructure_hook(dt.datetime, _datetime_to_json)
+
     blob.upload_from_string(
         data=json.dumps(converter.unstructure(metadata), sort_keys=True, indent=4),
         content_type="application/json",

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -61,7 +61,7 @@ class StatisticResult:
     to metric data.
     """
 
-    SCHEMA_VERSION = 3
+    SCHEMA_VERSION = 4
 
     metric: str
     statistic: str

--- a/jetstream/tests/test_metadata.py
+++ b/jetstream/tests/test_metadata.py
@@ -1,4 +1,3 @@
-from jetstream.external_config import ExternalConfig, ExternalConfigCollection
 import json
 from textwrap import dedent
 from unittest import mock
@@ -8,6 +7,7 @@ import requests
 import toml
 
 from jetstream.config import AnalysisSpec
+from jetstream.external_config import ExternalConfigCollection
 from jetstream.metadata import ExperimentMetadata, export_metadata
 from jetstream.statistics import StatisticResult
 
@@ -149,6 +149,9 @@ def test_metadata_from_config_missing_metadata(mock_get, experiments):
 def test_export_metadata(mock_storage_client, experiments):
     config_str = dedent(
         """
+        [experiment]
+        end_date = "2021-07-01"
+
         [metrics]
         weekly = ["view_about_logins", "my_cool_metric"]
 
@@ -196,7 +199,15 @@ def test_export_metadata(mock_storage_client, experiments):
                 }
             },
             "outcomes": {},
-            "external_config": null,
+            "external_config": {
+                "end_date": "2021-07-01",
+                "enrollment_period": null,
+                "reference_branch": null,
+                "skip": false,
+                "start_date": null,
+                "url": """
+        + '"https://github.com/mozilla/jetstream-config/blob/main/normandy-test-slug.toml"'
+        + r"""},
             "schema_version":"""
         + str(StatisticResult.SCHEMA_VERSION)
         + """

--- a/jetstream/tests/test_metadata.py
+++ b/jetstream/tests/test_metadata.py
@@ -1,3 +1,4 @@
+from jetstream.external_config import ExternalConfig, ExternalConfigCollection
 import json
 from textwrap import dedent
 from unittest import mock
@@ -45,7 +46,7 @@ def test_metadata_from_config(mock_get, experiments):
     assert metadata.metrics["my_cool_metric"].friendly_name == "Cool metric"
     assert metadata.metrics["my_cool_metric"].description == "Cool cool cool"
     assert metadata.metrics["my_cool_metric"].analysis_bases == ["enrollments"]
-    assert metadata.reference_branch == "b"
+    assert metadata.external_config is None
 
 
 @patch.object(requests.Session, "get")
@@ -66,7 +67,11 @@ def test_metadata_reference_branch(mock_get, experiments):
     config = spec.resolve(experiments[4])
     metadata = ExperimentMetadata.from_config(config)
 
-    assert metadata.reference_branch == "a"
+    assert metadata.external_config.reference_branch == "a"
+    assert (
+        metadata.external_config.url
+        == ExternalConfigCollection.JETSTREAM_CONFIG_URL + "/blob/main/normandy-test-slug.toml"
+    )
 
     config_str = dedent(
         """
@@ -81,7 +86,7 @@ def test_metadata_reference_branch(mock_get, experiments):
     config = spec.resolve(experiments[2])
     metadata = ExperimentMetadata.from_config(config)
 
-    assert metadata.reference_branch is None
+    assert metadata.external_config is None
 
 
 def test_metadata_with_outcomes(experiments, fake_outcome_resolver):
@@ -191,7 +196,7 @@ def test_export_metadata(mock_storage_client, experiments):
                 }
             },
             "outcomes": {},
-            "reference_branch": "b",
+            "external_config": null,
             "schema_version":"""
         + str(StatisticResult.SCHEMA_VERSION)
         + """


### PR DESCRIPTION
This adds `external_config` to the exported experiment metadata:
![Screen Shot 2021-08-18 at 11 16 42](https://user-images.githubusercontent.com/1239705/129951070-03418422-a3b0-498a-a1e7-738bf90e98f6.png)

Unblocks https://github.com/mozilla/experimenter/issues/6200