### PR TITLE
Temporarily disable resource usage logging

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -19,8 +19,9 @@ from pandas import DataFrame
 import jetstream.errors as errors
 from jetstream.bigquery_client import BigQueryClient
 from jetstream.config import AnalysisConfiguration
-from jetstream.diagnostics.resource_profiling_plugin import ResourceProfilingPlugin
-from jetstream.diagnostics.task_monitoring_plugin import TaskMonitoringPlugin
+
+# from jetstream.diagnostics.resource_profiling_plugin import ResourceProfilingPlugin
+# from jetstream.diagnostics.task_monitoring_plugin import TaskMonitoringPlugin
 from jetstream.dryrun import dry_run_query
 from jetstream.logging import LogConfiguration, LogPlugin
 from jetstream.statistics import (
@@ -455,23 +456,23 @@ class Analysis:
             client.register_worker_plugin(log_plugin)
 
             # add profiling plugins
-            resource_profiling_plugin = ResourceProfilingPlugin(
-                scheduler=_dask_cluster.scheduler,
-                project_id=self.log_config.log_project_id,
-                dataset_id=self.log_config.log_dataset_id,
-                table_id=self.log_config.task_profiling_log_table_id,
-                experiment=self.config.experiment.normandy_slug,
-            )
-            _dask_cluster.scheduler.add_plugin(resource_profiling_plugin)
+            # resource_profiling_plugin = ResourceProfilingPlugin(
+            #     scheduler=_dask_cluster.scheduler,
+            #     project_id=self.log_config.log_project_id,
+            #     dataset_id=self.log_config.log_dataset_id,
+            #     table_id=self.log_config.task_profiling_log_table_id,
+            #     experiment=self.config.experiment.normandy_slug,
+            # )
+            # _dask_cluster.scheduler.add_plugin(resource_profiling_plugin)
 
-            task_monitoring_plugin = TaskMonitoringPlugin(
-                scheduler=_dask_cluster.scheduler,
-                project_id=self.log_config.log_project_id,
-                dataset_id=self.log_config.log_dataset_id,
-                table_id=self.log_config.task_monitoring_log_table_id,
-                experiment=self.config.experiment.normandy_slug,
-            )
-            _dask_cluster.scheduler.add_plugin(task_monitoring_plugin)
+            # task_monitoring_plugin = TaskMonitoringPlugin(
+            #     scheduler=_dask_cluster.scheduler,
+            #     project_id=self.log_config.log_project_id,
+            #     dataset_id=self.log_config.log_dataset_id,
+            #     table_id=self.log_config.task_monitoring_log_table_id,
+            #     experiment=self.config.experiment.normandy_slug,
+            # )
+            # _dask_cluster.scheduler.add_plugin(task_monitoring_plugin)
 
         table_to_dataframe = dask.delayed(self.bigquery.table_to_dataframe)
 

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -1,7 +1,6 @@
 import datetime
 import datetime as dt
 from pathlib import Path
-from time import sleep
 
 import dask
 import mozanalysis
@@ -16,6 +15,9 @@ from jetstream.experimenter import Branch, Experiment
 from jetstream.logging import LogConfiguration
 from jetstream.metric import Metric
 from jetstream.statistics import BootstrapMean
+
+# from time import sleep
+
 
 TEST_DIR = Path(__file__).parent.parent
 
@@ -414,24 +416,24 @@ class TestAnalysisIntegration:
 
         # wait for profiling results to land in BigQuery
         # todo: improve this test as it might lead to flakiness
-        sleep(10)
+        # sleep(10)
 
-        assert (
-            client.client.get_table(f"{project_id}.{temporary_dataset}.task_profiling_logs")
-            is not None
-        )
+        # assert (
+        #     client.client.get_table(f"{project_id}.{temporary_dataset}.task_profiling_logs")
+        #     is not None
+        # )
 
-        task_profiling_logs = list(
-            client.client.list_rows(f"{project_id}.{temporary_dataset}.task_profiling_logs")
-        )
-        assert task_profiling_logs[0].get("max_cpu") >= 0
+        # task_profiling_logs = list(
+        #     client.client.list_rows(f"{project_id}.{temporary_dataset}.task_profiling_logs")
+        # )
+        # assert task_profiling_logs[0].get("max_cpu") >= 0
 
-        assert (
-            client.client.get_table(f"{project_id}.{temporary_dataset}.task_monitoring_logs")
-            is not None
-        )
+        # assert (
+        #     client.client.get_table(f"{project_id}.{temporary_dataset}.task_monitoring_logs")
+        #     is not None
+        # )
 
-        task_monitoring_logs = list(
-            client.client.list_rows(f"{project_id}.{temporary_dataset}.task_monitoring_logs")
-        )
-        assert len(task_monitoring_logs) > 0
+        # task_monitoring_logs = list(
+        #     client.client.list_rows(f"{project_id}.{temporary_dataset}.task_monitoring_logs")
+        # )
+        # assert len(task_monitoring_logs) > 0


### PR DESCRIPTION
While re-running the fission experiment, jetstream is running into `Exception while writing resource usage profiling data to BigQuery: 403 Quota exceeded: Your table exceeded quota for imports or query appe
nds per table. For more information, see https://cloud.google.com/bigquery/docs/troubleshoot-quotas`

disable for now.