### PR TITLE
Re-run `update_deps` due to ci failing wiht missing hash error

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ black==21.12b0
     # via pytest-black
 cachetools==4.2.4
     # via google-auth
-cattrs==1.8.0
+cattrs==1.9.0
     # via mozilla-jetstream
 certifi==2021.10.8
     # via requests
@@ -48,7 +48,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.24
     # via mozilla-jetstream
-google-api-core[grpc]==2.2.2
+google-api-core[grpc]==2.3.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ black==21.12b0
     # via pytest-black
 cachetools==4.2.4
     # via google-auth
-cattrs==1.9.0
+cattrs==1.8.0
     # via mozilla-jetstream
 certifi==2021.10.8
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,9 @@ cachetools==4.2.4 \
     # via
     #   -r requirements.in
     #   google-auth
-cattrs==1.9.0 \
-    --hash=sha256:1ef33f089e0a494e8d1b487508356f055c865b1955b125c00c991a4358543c80 \
-    --hash=sha256:8eca49962b1bfc09c24d442aa55688be88efe5c24aeef89d3be135614b95c678
+cattrs==1.8.0 \
+    --hash=sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53 \
+    --hash=sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1
     # via -r requirements.in
 certifi==2021.10.8 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,9 @@ cachetools==4.2.4 \
     # via
     #   -r requirements.in
     #   google-auth
-cattrs==1.8.0 \
-    --hash=sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53 \
-    --hash=sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1
+cattrs==1.9.0 \
+    --hash=sha256:1ef33f089e0a494e8d1b487508356f055c865b1955b125c00c991a4358543c80 \
+    --hash=sha256:8eca49962b1bfc09c24d442aa55688be88efe5c24aeef89d3be135614b95c678
     # via -r requirements.in
 certifi==2021.10.8 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
@@ -140,9 +140,9 @@ gitpython==3.1.24 \
     --hash=sha256:dc0a7f2f697657acc8d7f89033e8b1ea94dd90356b2983bca89dc8d2ab3cc647 \
     --hash=sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5
     # via -r requirements.in
-google-api-core[grpc]==2.2.2 \
-    --hash=sha256:97349cc18c2bb2415f64f1353a80273a289a61294ce3eb2f7ce682d251bdd997 \
-    --hash=sha256:e7853735d4f51f4212d6bf9750620d76fc0106c0f271be0c3f43b73501c7ddf9
+google-api-core[grpc]==2.3.0 \
+    --hash=sha256:538cd927bfe0f7c63bc1eb5fcadeeeb52f90bb29117dea87ae8cae48953d4c60 \
+    --hash=sha256:65fe1d9d8dde7a5ddc43d5cc134560c2a76b1a26c9f70c3c24f13b7910e89e10
     # via
     #   -r requirements.in
     #   google-cloud-bigquery


### PR DESCRIPTION
re-run update_deps due to ci failing wiht missing hash error:

```
#!/bin/bash -eo pipefail
python3.8 -m venv venv/
venv/bin/pip install --progress-bar off --upgrade -r requirements.txt
[...]
Requirement already satisfied: zict==2.0.0 in ./venv/lib/python3.8/site-packages (from -r requirements.txt (line 1060)) (2.0.0)
Requirement already satisfied: zipp==3.6.0 in ./venv/lib/python3.8/site-packages (from -r requirements.txt (line 1066)) (3.6.0)
Requirement already satisfied: setuptools in ./venv/lib/python3.8/site-packages (from distributed==2021.11.2->-r requirements.txt (line 115)) (56.0.0)
Collecting google-api-core<3.0.0dev,>=1.21.0
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    google-api-core<3.0.0dev,>=1.21.0 from https://files.pythonhosted.org/packages/e8/b3/a8165f2f96cca05dc0b013aa0041a5e39d328d7a83b95719988313ab8472/google_api_core-2.3.0-py2.py3-none-any.whl#sha256=65fe1d9d8dde7a5ddc43d5cc134560c2a76b1a26c9f70c3c24f13b7910e89e10 (from google-cloud-core==2.2.1->-r requirements.txt (line 177))
WARNING: You are using pip version 21.1.1; however, version 21.3.1 is available.
You should consider upgrading via the '/root/project/venv/bin/python3.8 -m pip install --upgrade pip' command.

Exited with code exit status 1

CircleCI received exit code 1
```