### PR TITLE
Feat(issue-932): Supported platform Configuration Part3

### DIFF
--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -211,12 +211,14 @@ def _generate_platform_config(config: MutableMapping[str, Any]) -> Dict[str, Pla
                 )
                 if segments_module and segments_module.lower() != "none"
                 else None,
-                "enrollments_query_type": platform_config.get("enrollments_query_type"),
+                "enrollments_query_type": platform_config.get(
+                    "enrollments_query_type", "glean-event"
+                ),
                 "validation_app_id": platform_config.get("validation_app_id"),
             }
         except ModuleNotFoundError as _err:
             raise PlatformConfigurationException(
-                str(_err) + "\nIf metrics or segments module does not exist,"
+                f"{_err}\nIf metrics or segments module does not exist,"
                 'please set the value to "None" inside platform_config.toml'
             )
 

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -194,9 +194,9 @@ def _generate_platform_config(config: MutableMapping[str, Any]) -> Dict[str, Pla
     processed_config = dict()
 
     for platform, platform_config in config["platform"].items():
-        config_spec_path = platform_config.get("config_spec_path")
-        metrics_module = platform_config.get("metrics_module")
-        segments_module = platform_config.get("segments_module")
+        config_spec_path = platform_config.get("config_spec_path", f"{platform}.toml")
+        metrics_module = platform_config.get("metrics_module", platform)
+        segments_module = platform_config.get("segments_module", platform)
 
         try:
             processed_config[platform] = {
@@ -215,7 +215,10 @@ def _generate_platform_config(config: MutableMapping[str, Any]) -> Dict[str, Pla
                 "validation_app_id": platform_config.get("validation_app_id"),
             }
         except ModuleNotFoundError as _err:
-            raise PlatformConfigurationException(_err)
+            raise PlatformConfigurationException(
+                str(_err) + "\nIf metrics or segments module does not exist,"
+                'please set the value to "None" inside platform_config.toml'
+            )
 
     return {
         platform: Platform(**platform_config)

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -920,6 +920,8 @@ class TestGeneratePlatformConfig:
                     "platform": {
                         "firefox_desktop": {
                             "config_spec_path": config_file,
+                            "metrics_module": "None",
+                            "segments_module": "None",
                             "enrollments_query_type": "normandy",
                             "validation_app_id": "firefox-desktop",
                         }
@@ -945,7 +947,7 @@ class TestGeneratePlatformConfig:
                             "enrollments_query_type": "glean-event",
                             "validation_app_id": "firefox-desktop",
                         },
-                        "dummy_app": {
+                        "desktop": {
                             "config_spec_path": config_file,
                             "enrollments_query_type": "normandy",
                             "validation_app_id": "EDI",
@@ -960,10 +962,10 @@ class TestGeneratePlatformConfig:
                         enrollments_query_type="glean-event",
                         validation_app_id="firefox-desktop",
                     ),
-                    "dummy_app": Platform(
+                    "desktop": Platform(
                         config_spec_path=CONFIG_DIRECTORY / config_file,
-                        metrics_module=None,
-                        segments_module=None,
+                        metrics_module=mozanalysis.metrics.desktop,
+                        segments_module=mozanalysis.segments.desktop,
                         enrollments_query_type="normandy",
                         validation_app_id="EDI",
                     ),
@@ -986,7 +988,7 @@ class TestGeneratePlatformConfig:
                 "platform": {
                     "firefox_desktop": {
                         "metrics_module": "desktop",
-                        "segments_module": "none",
+                        "segments_module": "test",
                         "enrollments_query_type": "glean-event",
                         "validation_app_id": "firefox-desktop",
                     },
@@ -1041,6 +1043,15 @@ class TestGeneratePlatformConfig:
                         "validation_app_id": "firefox-desktop",
                     },
                 }
+            },
+            {
+                "platform": {
+                    "dummy_app": {
+                        "config_spec_path": config_file,
+                        "enrollments_query_type": "normandy",
+                        "validation_app_id": "EDI",
+                    },
+                },
             },
         ],
     )

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -944,7 +944,6 @@ class TestGeneratePlatformConfig:
                             "config_spec_path": config_file,
                             "metrics_module": "desktop",
                             "segments_module": "none",
-                            "enrollments_query_type": "glean-event",
                             "validation_app_id": "firefox-desktop",
                         },
                         "desktop": {

--- a/platform_config.toml
+++ b/platform_config.toml
@@ -11,22 +11,22 @@ validation_app_id = "firefox-desktop"
 
 # Android platforms configuration
 [platform.fenix]
-config_spec_path = "fenix.toml"
-metrics_module = "fenix"
+# config_spec_path = "fenix.toml"
+# metrics_module = "fenix"
 segments_module = "None"
 enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.fenix"
 
 [platform.focus_android]
-config_spec_path = "focus_android.toml"
-metrics_module = "focus_android"
+# config_spec_path = "focus_android.toml"
+# metrics_module = "focus_android"
 segments_module = "None"
 enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.focus"
 
 [platform.klar_android]
-config_spec_path = "klar_android.toml"
-metrics_module = "klar_android"
+# config_spec_path = "klar_android.toml"
+# metrics_module = "klar_android"
 segments_module = "None"
 enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.klar"
@@ -34,22 +34,22 @@ validation_app_id = "org.mozilla.klar"
 
 # ios platforms configuration
 [platform.firefox_ios]
-config_spec_path = "firefox_ios.toml"
-metrics_module = "firefox_ios"
+# config_spec_path = "firefox_ios.toml"
+# metrics_module = "firefox_ios"
 segments_module = "None"
 enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.ios.FirefoxBeta"
 
 [platform.focus_ios]
-config_spec_path = "focus_ios.toml"
-metrics_module = "focus_ios"
+# config_spec_path = "focus_ios.toml"
+# metrics_module = "focus_ios"
 segments_module = "None"
 enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.ios.Focus"
 
 [platform.klar_ios]
-config_spec_path = "klar_ios.toml"
-metrics_module = "klar_ios"
+# config_spec_path = "klar_ios.toml"
+# metrics_module = "klar_ios"
 segments_module = "None"
 enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.ios.Klar"

--- a/platform_config.toml
+++ b/platform_config.toml
@@ -11,45 +11,27 @@ validation_app_id = "firefox-desktop"
 
 # Android platforms configuration
 [platform.fenix]
-# config_spec_path = "fenix.toml"
-# metrics_module = "fenix"
 segments_module = "None"
-enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.fenix"
 
 [platform.focus_android]
-# config_spec_path = "focus_android.toml"
-# metrics_module = "focus_android"
 segments_module = "None"
-enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.focus"
 
 [platform.klar_android]
-# config_spec_path = "klar_android.toml"
-# metrics_module = "klar_android"
 segments_module = "None"
-enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.klar"
 
 
 # ios platforms configuration
 [platform.firefox_ios]
-# config_spec_path = "firefox_ios.toml"
-# metrics_module = "firefox_ios"
 segments_module = "None"
-enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.ios.FirefoxBeta"
 
 [platform.focus_ios]
-# config_spec_path = "focus_ios.toml"
-# metrics_module = "focus_ios"
 segments_module = "None"
-enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.ios.Focus"
 
 [platform.klar_ios]
-# config_spec_path = "klar_ios.toml"
-# metrics_module = "klar_ios"
 segments_module = "None"
-enrollments_query_type = "glean-event"
 validation_app_id = "org.mozilla.ios.Klar"


### PR DESCRIPTION
# Feat(issue-932): Supported platform Configuration Part3

Now `config_spec_path`, `metrics_module`, and `segments_module` config values get defaulted to platform name and can be overwritten from inside `platform_config.toml` file.