### PR TITLE
Addressing MyPy Converter error with cattr==1.9.0

### DIFF
--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -154,13 +154,13 @@ class ExperimentV6:
             lambda num, _: dt.datetime.strptime(num, "%Y-%m-%d"),
         )
         converter.register_structure_hook(
-            cls,
             cattr.gen.make_dict_structure_fn(
                 cls,
                 converter,
                 _appName=cattr.override(rename="appName"),
                 _appId=cattr.override(rename="appId"),
             ),
+            cls,
         )
         return converter.structure(d, cls)
 

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ black==21.12b0
     # via pytest-black
 cachetools==4.2.4
     # via google-auth
-cattrs==1.8.0
+cattrs==1.9.0
     # via mozilla-jetstream
 certifi==2021.10.8
     # via requests


### PR DESCRIPTION
Addressing MyPy Converter error with cattr==1.9.0


