### PR TITLE
cattrs bumped up to 1.10.0 and type check ignored due to what appears to be a bug in cattrs

### DIFF
--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -160,7 +160,9 @@ class ExperimentV6:
                 converter,
                 _appName=cattr.override(rename="appName"),
                 _appId=cattr.override(rename="appId"),
-            ),
+            ),  # type: ignore
+            # Ignore type check for now as it appears to be a bug in cattrs library
+            # for more info see issue: https://github.com/mozilla/jetstream/issues/995
         )
         return converter.structure(d, cls)
 

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ black==21.12b0
     # via pytest-black
 cachetools==4.2.4
     # via google-auth
-cattrs==1.8.0
+cattrs==1.10.0
     # via mozilla-jetstream
 certifi==2021.10.8
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,9 @@ cachetools==4.2.4 \
     # via
     #   -r requirements.in
     #   google-auth
-cattrs==1.8.0 \
-    --hash=sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53 \
-    --hash=sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1
+cattrs==1.10.0 \
+    --hash=sha256:211800f725cdecedcbcf4c753bbd22d248312b37d130f06045434acb7d9b34e1 \
+    --hash=sha256:35dd9063244263e63bd0bd24ea61e3015b00272cead084b2c40d788b0f857c46
     # via -r requirements.in
 certifi==2021.10.8 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \


### PR DESCRIPTION
cattrs bumped up to 1.10.0 and type check ignored due to what appears to be a bug in cattrs

See this issue for more info: https://github.com/mozilla/jetstream/issues/995