### PR TITLE
tweaked dockerfile and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .git
 .tox
+venv/
+.github/
+.circleci/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.8
+ARG PYTHON_VERSION=3.8
+FROM python:${PYTHON_VERSION}
+
+ARG PIP_VERSION=22.0.3
+COPY requirements.txt requirements.txt
+RUN python -m pip install --no-cache-dir --upgrade pip==${PIP_VERSION} \
+    && python -m pip install --no-cache-dir -r requirements.txt
 
 RUN mkdir -p /app
 WORKDIR /app
-
 COPY . .
-RUN pip install -r requirements.txt
 
-RUN pip install .
+RUN python -m pip install --no-cache-dir .
 
 ENTRYPOINT ["jetstream"]


### PR DESCRIPTION

Made some tweaks to the docker image to improve the build time (doing copy all after initial pip install)
Added a couple of folders to dockerignore (I don't believe the app needs those) and pip keeps no cache to help reduce the image size:

<img width="433" alt="image" src="https://user-images.githubusercontent.com/42538694/154059126-39704237-d54c-4b85-871b-64f0ebf0dd49.png">

Not a huge difference.