### PR TITLE
Fear(cirrus-753): parametise outcome spotlight multi message id part 2 

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -419,7 +419,6 @@ class Analysis:
                 UNION ALL
                 SELECT '00000' AS client_id,
                     'test' AS branch,
-                    '1' AS message_id,
                     DATE('2020-01-01') AS enrollment_date,
                     DATE('2020-01-01') AS exposure_date,
                     1 AS num_enrollment_events,

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -412,7 +412,6 @@ class Analysis:
             """WITH enrollments_table AS (
                 SELECT '00000' AS client_id,
                     'test' AS branch,
-                    '1' AS message_id,
                     DATE('2020-01-01') AS enrollment_date,
                     DATE('2020-01-01') AS exposure_date,
                     1 AS num_enrollment_events,

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -412,6 +412,7 @@ class Analysis:
             """WITH enrollments_table AS (
                 SELECT '00000' AS client_id,
                     'test' AS branch,
+                    '1' AS message_id,
                     DATE('2020-01-01') AS enrollment_date,
                     DATE('2020-01-01') AS exposure_date,
                     1 AS num_enrollment_events,
@@ -419,6 +420,7 @@ class Analysis:
                 UNION ALL
                 SELECT '00000' AS client_id,
                     'test' AS branch,
+                    '1' AS message_id,
                     DATE('2020-01-01') AS enrollment_date,
                     DATE('2020-01-01') AS exposure_date,
                     1 AS num_enrollment_events,

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -130,7 +130,9 @@ class ParameterDefinition:
         the rules defined here.
         """
 
-        if self.distinct_by_branch and not isinstance(self.value, dict) and not isinstance(self.default, dict):
+        if self.distinct_by_branch and not (
+            isinstance(self.value, dict) or isinstance(self.default, dict)
+        ):
             error_msg = (
                 f"Parameter {self.name} configured "
                 "to be distinct by branch, a mapping expected in the following format: "
@@ -139,7 +141,9 @@ class ParameterDefinition:
             )
             raise InvalidConfigurationException(error_msg)
 
-        elif not self.distinct_by_branch and not isinstance(self.value, str) and not isinstance(self.default, str):
+        elif not self.distinct_by_branch and not (
+            isinstance(self.value, str) or isinstance(self.default, str)
+        ):
             error_msg = (
                 f"Parameter {self.name} configured "
                 "to not be distinct by branch, but wrong value type provided. "
@@ -934,7 +938,11 @@ class AnalysisSpec:
         default_value = param_1.default or param_2.default
         value = param_1.value or param_2.value or default_value
 
-        final_value = {**(default_value or dict()), **value} if isinstance(value, dict) and isinstance(default_value, dict) else value
+        final_value = (
+            {**(default_value or dict()), **value}
+            if isinstance(value, dict) and isinstance(default_value, dict)
+            else value
+        )
 
         return ParameterDefinition(
             **{
@@ -942,10 +950,12 @@ class AnalysisSpec:
                 "friendly_name": getattr(param_1, "friendly_name", None)
                 or getattr(param_2, "friendly_name"),
                 "description": getattr(param_1, "description", None) or param_2.description,
-                "value": {
-                    branch: branch_value for branch, branch_value in final_value.items()
-                } if isinstance(final_value, dict) else final_value,
-                "default": getattr(param_1, "default", None) or default_value,
+                "value": {branch: branch_value for branch, branch_value in final_value.items()}
+                if isinstance(final_value, dict)
+                else final_value,
+                "default": getattr(param_1, "default", None)
+                or default_value
+                or (dict() if isinstance(final_value, dict) else None),
                 "distinct_by_branch": getattr(param_1, "distinct_by_branch", None)
                 or param_2.distinct_by_branch,
             }

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -505,6 +505,7 @@ class MetricDefinition:
                                 for branch, value in param_definition.value.items()
                             ]
                         )
+                        + " END"
                     }
                 )
             else:

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -138,6 +138,7 @@ class ParameterDefinition:
                 "to be distinct by branch, a mapping expected in the following format: "
                 'for values: value.branch_1 = "1"'
                 'and defaults: default.branch_1 = "1"'
+                "See https://experimenter.info/jetstream/outcomes#parameterizing-outcomes for more information"  # noqa: E501
             )
             raise InvalidConfigurationException(error_msg)
 
@@ -150,6 +151,7 @@ class ParameterDefinition:
                 "Expected format: "
                 f'value = "param_value", provided: {self.value}'
                 f'default = "", provided: {self.default}'
+                "See https://experimenter.info/jetstream/outcomes#parameterizing-outcomes for more information"  # noqa: E501
             )
             raise InvalidConfigurationException(error_msg)
 

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -121,14 +121,6 @@ class ParameterDefinition:
     distinct_by_branch: Optional[bool] = False
     default: Optional[Union[str, Dict[str, Any]]] = None
 
-    @classmethod
-    def from_dict(cls, d: Mapping[str, Any]) -> "ParameterDefinition":
-        """
-        Converts a dictionary object into a ParameterDefinition structured object.
-        """
-
-        return cls(**d)
-
     def validate(self) -> "ParameterDefinition":
         """
         Validates that branch related configuration is correct.
@@ -159,7 +151,7 @@ class ParameterDefinition:
 
 
 _converter.register_structure_hook(
-    ParameterDefinition, lambda obj, _type: ParameterDefinition.from_dict(obj)
+    ParameterDefinition, lambda obj, _type: ParameterDefinition(**obj)
 )
 
 
@@ -937,11 +929,11 @@ class AnalysisSpec:
         param_2 is used for setting default values if missing in param_1
         """
 
-        value = getattr(param_1, "value", None)
+        value = param_1.value or param_2.value
         default_value = param_1.default or param_2.default
 
-        return ParameterDefinition.from_dict(
-            {
+        return ParameterDefinition(
+            **{
                 "name": getattr(param_1, "name", None) or getattr(param_2, "name"),
                 "friendly_name": getattr(param_1, "friendly_name", None)
                 or getattr(param_2, "friendly_name"),

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -512,8 +512,9 @@ class MetricDefinition:
         select_expr_template: Union[str, jinja2.nodes.Template],
     ) -> Optional[str]:
         """
-        # TODO: comment
-        # unit test?
+        Takes in param configuration and converts it to a string which should be passed
+        into select statement in place of the param
+        # TODO: unit test?
         """
 
         if isinstance(param_config, ParameterDefinition) and not param_config.distinct_by_branch:

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -134,7 +134,7 @@ class ParameterDefinition:
             error_msg = (
                 f"Parameter {self.name} configured "
                 "to be distinct by branch, a mapping expected in the following format: "
-                'value = {"branch_1": "1"}'
+                'value.branch_1 = "1"'
             )
             raise InvalidConfigurationException(error_msg)
 

--- a/jetstream/external_config.py
+++ b/jetstream/external_config.py
@@ -65,6 +65,7 @@ def validate_config_settings(config_file: Path) -> None:
         "data_sources",
         "friendly_name",
         "description",
+        "parameters",
     )
 
     core_config_keys_specified = config.keys()

--- a/jetstream/external_config.py
+++ b/jetstream/external_config.py
@@ -145,8 +145,11 @@ class ExternalOutcome:
             app_id=app_id,
             app_name=self.platform,
         )
+
         spec = AnalysisSpec.default_for_experiment(dummy_experiment)
         spec.merge_outcome(self.spec)
+        spec.merge_parameters(self.spec.parameters)
+
         conf = spec.resolve(dummy_experiment)
         Analysis("no project", "no dataset", conf).validate()
 

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -340,7 +340,9 @@ def fake_outcome_resolver(monkeypatch):
             )
             data["parameterized_distinct_by_branch"] = external_config.ExternalOutcome(
                 slug="parameterized",
-                spec=config.OutcomeSpec.from_dict(toml.loads(parameterized_distinct_by_branch_config)),
+                spec=config.OutcomeSpec.from_dict(
+                    toml.loads(parameterized_distinct_by_branch_config)
+                ),
                 platform="firefox_desktop",
                 commit_hash="000000",
             )

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -127,21 +127,6 @@ def experiments():
             app_name="firefox_desktop",
             app_id="firefox-desktop",
         ),
-        Experiment(
-            experimenter_slug="test_slug",
-            type="pref",
-            status="Live",
-            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
-            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
-            proposed_enrollment=7,
-            branches=[],
-            normandy_slug="normandy-test-slug",
-            reference_branch=None,
-            is_high_population=True,
-            outcomes=["parameterized_distinct_by_branch"],
-            app_name="firefox_desktop",
-            app_id="firefox-desktop",
-        ),
     ]
 
 
@@ -291,28 +276,8 @@ def fake_outcome_resolver(monkeypatch):
         [parameters.id]
         friendly_name = "Some random ID"
         description = "A random ID used to count samples"
-        default = "default_value"
+        default = "700"
         distinct_by_branch = false
-        """
-    )
-
-    parameterized_distinct_by_branch_config = dedent(
-        """
-        friendly_name = "Outcome with parameter same across all branches"
-        description = "Outcome that has a parameter that is the same across all branches"
-        default_metrics = ["sample_id_count"]
-
-        [metrics.sample_id_count]
-        data_source = "main"
-        select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
-
-        [metrics.sample_id_count.statistics.bootstrap_mean]
-
-        [parameters.id]
-        friendly_name = "Some random ID"
-        description = "A random ID used to count samples"
-        default = "default_value"
-        distinct_by_branch = true
         """
     )
 
@@ -335,14 +300,6 @@ def fake_outcome_resolver(monkeypatch):
             data["parameterized"] = external_config.ExternalOutcome(
                 slug="parameterized",
                 spec=config.OutcomeSpec.from_dict(toml.loads(parameterised_config)),
-                platform="firefox_desktop",
-                commit_hash="000000",
-            )
-            data["parameterized_distinct_by_branch"] = external_config.ExternalOutcome(
-                slug="parameterized",
-                spec=config.OutcomeSpec.from_dict(
-                    toml.loads(parameterized_distinct_by_branch_config)
-                ),
                 platform="firefox_desktop",
                 commit_hash="000000",
             )

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -127,6 +127,21 @@ def experiments():
             app_name="firefox_desktop",
             app_id="firefox-desktop",
         ),
+        Experiment(
+            experimenter_slug="test_slug",
+            type="pref",
+            status="Live",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            branches=[],
+            normandy_slug="normandy-test-slug",
+            reference_branch=None,
+            is_high_population=True,
+            outcomes=["parameterized_distinct_by_branch"],
+            app_name="firefox_desktop",
+            app_id="firefox-desktop",
+        ),
     ]
 
 
@@ -281,6 +296,26 @@ def fake_outcome_resolver(monkeypatch):
         """
     )
 
+    parameterized_distinct_by_branch_config = dedent(
+        """
+        friendly_name = "Outcome with parameter same across all branches"
+        description = "Outcome that has a parameter that is the same across all branches"
+        default_metrics = ["sample_id_count"]
+
+        [metrics.sample_id_count]
+        data_source = "main"
+        select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
+
+        [metrics.sample_id_count.statistics.bootstrap_mean]
+
+        [parameters.id]
+        friendly_name = "Some random ID"
+        description = "A random ID used to count samples"
+        default = "default_value"
+        distinct_by_branch = true
+        """
+    )
+
     class FakeOutcomeResolver:
         @property
         def data(self) -> Dict[str, external_config.ExternalOutcome]:
@@ -300,6 +335,12 @@ def fake_outcome_resolver(monkeypatch):
             data["parameterized"] = external_config.ExternalOutcome(
                 slug="parameterized",
                 spec=config.OutcomeSpec.from_dict(toml.loads(parameterised_config)),
+                platform="firefox_desktop",
+                commit_hash="000000",
+            )
+            data["parameterized_distinct_by_branch"] = external_config.ExternalOutcome(
+                slug="parameterized",
+                spec=config.OutcomeSpec.from_dict(toml.loads(parameterized_distinct_by_branch_config)),
                 platform="firefox_desktop",
                 commit_hash="000000",
             )

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -127,6 +127,21 @@ def experiments():
             app_name="firefox_desktop",
             app_id="firefox-desktop",
         ),
+        Experiment(
+            experimenter_slug="test_slug",
+            type="pref",
+            status="Live",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            branches=[],
+            normandy_slug="normandy-test-slug",
+            reference_branch=None,
+            is_high_population=True,
+            outcomes=["parameterised_distinct_by_branch_config"],
+            app_name="firefox_desktop",
+            app_id="firefox-desktop",
+        ),
     ]
 
 
@@ -281,6 +296,27 @@ def fake_outcome_resolver(monkeypatch):
         """
     )
 
+    parameterised_distinct_by_branch_config = dedent(
+        """
+        friendly_name = "Outcome with parameter same across all branches"
+        description = "Outcome that has a parameter that is the same across all branches"
+        default_metrics = ["sample_id_count"]
+
+        [metrics.sample_id_count]
+        data_source = "main"
+        select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
+
+        [metrics.sample_id_count.statistics.bootstrap_mean]
+
+        [parameters.id]
+        friendly_name = "Some random ID"
+        description = "A random ID used to count samples"
+        distinct_by_branch = true
+
+        default.branch_1 = 1
+        """
+    )
+
     class FakeOutcomeResolver:
         @property
         def data(self) -> Dict[str, external_config.ExternalOutcome]:
@@ -300,6 +336,14 @@ def fake_outcome_resolver(monkeypatch):
             data["parameterized"] = external_config.ExternalOutcome(
                 slug="parameterized",
                 spec=config.OutcomeSpec.from_dict(toml.loads(parameterised_config)),
+                platform="firefox_desktop",
+                commit_hash="000000",
+            )
+            data["parameterised_distinct_by_branch_config"] = external_config.ExternalOutcome(
+                slug="parameterized",
+                spec=config.OutcomeSpec.from_dict(
+                    toml.loads(parameterised_distinct_by_branch_config)
+                ),
                 platform="firefox_desktop",
                 commit_hash="000000",
             )

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -988,6 +988,84 @@ class TestOutcomes:
             == "COUNTIF(sample_id = COUNTIF(sample_id = 1234 AND e.branch_name = 'my_branch_1') OR COUNTIF(sample_id = 567 AND e.branch_name = 'my_branch_2'))"
         )
 
+    def test_resolving_parameters_distinct_by_branch_missing_branch_name_raises(self, experiments, fake_outcome_resolver):
+        """
+        If distinct_by_branch is set to `true`
+        `branch_name` value should be specified
+        otherwise we raise an exception
+        """
+
+        config_str = dedent(
+            """
+            # distinct_by_branch True inherited from Outcome
+            [[parameters.id]]
+            value = "1234"
+
+            [[parameters.id]]
+            value = "567"
+            branch_name = "my_branch_2"
+
+            [metrics]
+            weekly = ["view_about_logins", "my_cool_metric"]
+            daily = ["my_cool_metric"]
+
+            [metrics.my_cool_metric]
+            data_source = "main"
+            select_expression = "{{agg_histogram_mean('payload.content.my_cool_histogram')}}"
+            friendly_name = "Cool metric"
+            description = "Cool cool cool 😎"
+            bigger_is_better = false
+
+            [metrics.my_cool_metric.statistics.bootstrap_mean]
+
+            [metrics.view_about_logins.statistics.bootstrap_mean]
+            """
+        )
+
+        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+
+        with pytest.raises(Exception):  # TODO: update the exception
+            spec.resolve(experiments[7])
+
+    def test_resolving_parameters_distinct_by_branch_false_branch_name_specified_raises(self, experiments, fake_outcome_resolver):
+        """
+        If distinct_by_branch is set to `false`
+        `branch_name` value should not be specified
+        otherwise we raise an exception
+        """
+
+        config_str = dedent(
+            """
+            # distinct_by_branch false inherited from Outcome
+            [[parameters.id]]
+            value = "1234"
+
+            [[parameters.id]]
+            value = "567"
+            branch_name = "my_branch_2"
+
+            [metrics]
+            weekly = ["view_about_logins", "my_cool_metric"]
+            daily = ["my_cool_metric"]
+
+            [metrics.my_cool_metric]
+            data_source = "main"
+            select_expression = "{{agg_histogram_mean('payload.content.my_cool_histogram')}}"
+            friendly_name = "Cool metric"
+            description = "Cool cool cool 😎"
+            bigger_is_better = false
+
+            [metrics.my_cool_metric.statistics.bootstrap_mean]
+
+            [metrics.view_about_logins.statistics.bootstrap_mean]
+            """
+        )
+
+        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+        with pytest.raises(Exception):  # TODO: update the exception
+            spec.resolve(experiments[6])
+
+
     def test_unsupported_platform_outcomes(self, experiments, fake_outcome_resolver):
         spec = config.AnalysisSpec.from_dict(toml.loads(""))
         experiment = Experiment(

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -12,6 +12,7 @@ from mozanalysis.experiment import AnalysisBasis
 
 from jetstream import AnalysisPeriod, config
 from jetstream.config import AnalysisWindow, Platform, _generate_platform_config
+from jetstream.errors import InvalidConfigurationException
 from jetstream.experimenter import Experiment
 from jetstream.exposure_signal import ExposureSignal
 from jetstream.platform import PlatformConfigurationException
@@ -1024,7 +1025,7 @@ class TestOutcomes:
 
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
 
-        with pytest.raises(Exception):  # TODO: update the exception
+        with pytest.raises(InvalidConfigurationException):
             spec.resolve(experiments[7])
 
     def test_resolving_parameters_distinct_by_branch_false_branch_name_specified_raises(self, experiments, fake_outcome_resolver):
@@ -1062,7 +1063,7 @@ class TestOutcomes:
         )
 
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        with pytest.raises(Exception):  # TODO: update the exception
+        with pytest.raises(InvalidConfigurationException):
             spec.resolve(experiments[6])
 
 

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -11,7 +11,14 @@ import toml
 from mozanalysis.experiment import AnalysisBasis
 
 from jetstream import AnalysisPeriod, config
-from jetstream.config import AnalysisWindow, Platform, _generate_platform_config, ParameterDefinition, ParameterSpec, MetricDefinition
+from jetstream.config import (
+    AnalysisWindow,
+    MetricDefinition,
+    ParameterDefinition,
+    ParameterSpec,
+    Platform,
+    _generate_platform_config,
+)
 from jetstream.errors import InvalidConfigurationException
 from jetstream.experimenter import Experiment
 from jetstream.exposure_signal import ExposureSignal
@@ -985,9 +992,9 @@ class TestOutcomes:
         assert "my_cool_metric" in weekly_metrics
 
         assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
-            "COUNTIF(sample_id = 1234 "\
-            "AND e.branch_name = 'my_branch_1') "\
-            "OR COUNTIF(sample_id = 567 "\
+            "COUNTIF(sample_id = 1234 "
+            "AND e.branch_name = 'my_branch_1') "
+            "OR COUNTIF(sample_id = 567 "
             "AND e.branch_name = 'my_branch_2')"
         )
 
@@ -1093,6 +1100,7 @@ class TestOutcomes:
         with pytest.raises(ValueError):
             spec.resolve(experiment)
 
+
 class TestParameterDefinition:
     """
     Class for testing functionality related to ParameterDefinition
@@ -1103,12 +1111,12 @@ class TestParameterDefinition:
         assert ParameterDefinition(name="test") == actual
 
         assert actual.name == "test"
-        assert actual.friendly_name == None
-        assert actual.description == None
-        assert actual.value == None
-        assert actual.distinct_by_branch == False
-        assert actual.default == None
-        assert actual.branch_name == None
+        assert not actual.friendly_name
+        assert not actual.description
+        assert not actual.value
+        assert not actual.distinct_by_branch
+        assert not actual.default
+        assert not actual.branch_name
 
     def test_from_dict_all_values_set(self):
         expected = ParameterDefinition(
@@ -1196,22 +1204,64 @@ class TestParameterSpec:
 
 
 class TestMetricDefinition:
-
     @pytest.mark.parametrize(
-        'input,expected',
+        "input,expected",
         (
-            ([{"param": ParameterDefinition(name="param", value="1")}, "param = {{ parameters.param }}"], "param = 1"),
-            ([{"param": ParameterDefinition(name="param", value="1")}, "{{ parameters.param }}"], "1"),
+            (
+                [
+                    {"param": ParameterDefinition(name="param", value="1")},
+                    "param = {{ parameters.param }}",
+                ],
+                "param = 1",
+            ),
+            (
+                [{"param": ParameterDefinition(name="param", value="1")}, "{{ parameters.param }}"],
+                "1",
+            ),
             ([{"param": None}, "{{ parameters.param }}"], ""),
             ([dict(), ""], ""),
             ([{"param": ParameterDefinition(name="param", value="1")}, ""], ""),
-            ([{"param": [
-                ParameterDefinition(name="param", distinct_by_branch=True, value="value_1", branch_name="my_branch_1"),
-            ],}, "value = {{ parameters.param }}"], "value = value_1 AND e.branch_name = 'my_branch_1'"),
-            ([{"param": [
-                ParameterDefinition(name="param", distinct_by_branch=True, value="value_1", branch_name="my_branch_1"),
-                ParameterDefinition(name="param", distinct_by_branch=True, value="value_2", branch_name="my_branch_2"),
-            ],}, "value = {{ parameters.param }}"], "value = value_1 AND e.branch_name = 'my_branch_1' OR value = value_2 AND e.branch_name = 'my_branch_2'"),
+            (
+                [
+                    {
+                        "param": [
+                            ParameterDefinition(
+                                name="param",
+                                distinct_by_branch=True,
+                                value="value_1",
+                                branch_name="my_branch_1",
+                            ),
+                        ],
+                    },
+                    "value = {{ parameters.param }}",
+                ],
+                "value = value_1 AND e.branch_name = 'my_branch_1'",
+            ),
+            (
+                [
+                    {
+                        "param": [
+                            ParameterDefinition(
+                                name="param",
+                                distinct_by_branch=True,
+                                value="value_1",
+                                branch_name="my_branch_1",
+                            ),
+                            ParameterDefinition(
+                                name="param",
+                                distinct_by_branch=True,
+                                value="value_2",
+                                branch_name="my_branch_2",
+                            ),
+                        ],
+                    },
+                    "value = {{ parameters.param }}",
+                ],
+                (
+                    "value = value_1 AND e.branch_name = 'my_branch_1' "
+                    "OR value = value_2 AND e.branch_name = 'my_branch_2'"
+                ),
+            ),
         ),
     )
     def test_generate_select_expression(self, input, expected):

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -1056,7 +1056,8 @@ class TestOutcomes:
 
         assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
             """COUNTIF(sample_id = CASE e.branch """
-            """WHEN "branch_3" THEN "444" WHEN "branch_1" THEN "123" WHEN "branch_2" THEN "456" END)"""
+            """WHEN "branch_3" THEN "444" WHEN "branch_1" """
+            """THEN "123" WHEN "branch_2" THEN "456" END)"""
         )
 
     def test_resolving_parameters_default_value(self, experiments, fake_outcome_resolver):
@@ -1213,6 +1214,7 @@ class TestParameterDefinition:
         (
             (ParameterDefinition(name="test", value="1", distinct_by_branch=False)),
             (ParameterDefinition(name="test", value={"branch_1": "1"}, distinct_by_branch=True)),
+            (ParameterDefinition(name="test", default={"branch_1": "1"}, distinct_by_branch=True)),
         ),
     )
     def test_validate(self, input):

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -1198,38 +1198,6 @@ class TestParameterDefinition:
     Class for testing functionality related to ParameterDefinition
     """
 
-    def test_from_dict(self):
-        actual = ParameterDefinition(**{"name": "test"})
-        assert ParameterDefinition(name="test") == actual
-
-        assert actual.name == "test"
-        assert not actual.friendly_name
-        assert not actual.description
-        assert not actual.value
-        assert not actual.distinct_by_branch
-        assert not actual.default
-
-    def test_from_dict_all_values_set(self):
-        expected = ParameterDefinition(
-            name="test",
-            friendly_name="Test Definition",
-            description="Used for testing",
-            value="123",
-            distinct_by_branch=True,
-            default="default",
-        )
-
-        test_dict = {
-            "name": "test",
-            "friendly_name": "Test Definition",
-            "description": "Used for testing",
-            "value": "123",
-            "distinct_by_branch": True,
-            "default": "default",
-        }
-
-        assert expected == ParameterDefinition(**test_dict)
-
     @pytest.mark.parametrize(
         "input",
         (

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -1052,7 +1052,7 @@ class TestOutcomes:
 
         assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
             """COUNTIF(sample_id = CASE e.branch """
-            """WHEN "branch_1" THEN "123" WHEN "branch_2" THEN "456")"""
+            """WHEN "branch_1" THEN "123" WHEN "branch_2" THEN "456" END)"""
         )
 
     def test_resolving_parameters_default_value(self, experiments, fake_outcome_resolver):
@@ -1132,7 +1132,7 @@ class TestOutcomes:
 
         assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
             """COUNTIF(sample_id = CASE e.branch """
-            """WHEN "branch_1" THEN "700" WHEN "branch_2" THEN "700")"""
+            """WHEN "branch_1" THEN "700" WHEN "branch_2" THEN "700" END)"""
         )
 
     def test_resolving_parameters_distinct_by_branch_missing_branch_name_raises(
@@ -1319,7 +1319,7 @@ class TestMetricDefinition:
                     },
                     "{{parameters.param}}",
                 ],
-                'CASE e.branch WHEN "branch_1" THEN "1"',
+                'CASE e.branch WHEN "branch_1" THEN "1" END',
             ),
             (
                 [
@@ -1337,7 +1337,7 @@ class TestMetricDefinition:
                 ],
                 (
                     """COUNTIF(id = CASE e.branch """
-                    """WHEN "branch_1" THEN "1" WHEN "branch_2" THEN "2")"""
+                    """WHEN "branch_1" THEN "1" WHEN "branch_2" THEN "2" END)"""
                 ),
             ),
         ),

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -984,12 +984,17 @@ class TestOutcomes:
         assert "view_about_logins" in weekly_metrics
         assert "my_cool_metric" in weekly_metrics
 
-        assert (
-            cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression
-            == "COUNTIF(sample_id = COUNTIF(sample_id = 1234 AND e.branch_name = 'my_branch_1') OR COUNTIF(sample_id = 567 AND e.branch_name = 'my_branch_2'))"
+        assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
+            "COUNTIF(sample_id = "
+            "COUNTIF(sample_id = 1234 "
+            "AND e.branch_name = 'my_branch_1') "
+            "OR COUNTIF(sample_id = 567 "
+            "AND e.branch_name = 'my_branch_2'))"
         )
 
-    def test_resolving_parameters_distinct_by_branch_missing_branch_name_raises(self, experiments, fake_outcome_resolver):
+    def test_resolving_parameters_distinct_by_branch_missing_branch_name_raises(
+        self, experiments, fake_outcome_resolver
+    ):
         """
         If distinct_by_branch is set to `true`
         `branch_name` value should be specified
@@ -1028,7 +1033,9 @@ class TestOutcomes:
         with pytest.raises(InvalidConfigurationException):
             spec.resolve(experiments[7])
 
-    def test_resolving_parameters_distinct_by_branch_false_branch_name_specified_raises(self, experiments, fake_outcome_resolver):
+    def test_resolving_parameters_distinct_by_branch_false_branch_name_specified_raises(
+        self, experiments, fake_outcome_resolver
+    ):
         """
         If distinct_by_branch is set to `false`
         `branch_name` value should not be specified
@@ -1065,7 +1072,6 @@ class TestOutcomes:
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         with pytest.raises(InvalidConfigurationException):
             spec.resolve(experiments[6])
-
 
     def test_unsupported_platform_outcomes(self, experiments, fake_outcome_resolver):
         spec = config.AnalysisSpec.from_dict(toml.loads(""))

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -1051,8 +1051,8 @@ class TestOutcomes:
         assert "my_cool_metric" in weekly_metrics
 
         assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
-            "COUNTIF(sample_id = 123 AND e.branch_name = 'branch_1') "
-            "OR COUNTIF(sample_id = 456 AND e.branch_name = 'branch_2')"
+            """COUNTIF(sample_id = CASE e.branch """
+            """WHEN "branch_1" THEN "123" WHEN "branch_2" THEN "456")"""
         )
 
     def test_resolving_parameters_default_value(self, experiments, fake_outcome_resolver):
@@ -1131,8 +1131,8 @@ class TestOutcomes:
         assert "my_cool_metric" in weekly_metrics
 
         assert cfg.metrics[AnalysisPeriod.WEEK][0].metric.select_expression == (
-            "COUNTIF(sample_id = 700 AND e.branch_name = 'branch_1') "
-            "OR COUNTIF(sample_id = 700 AND e.branch_name = 'branch_2')"
+            """COUNTIF(sample_id = CASE e.branch """
+            """WHEN "branch_1" THEN "700" WHEN "branch_2" THEN "700")"""
         )
 
     def test_resolving_parameters_distinct_by_branch_missing_branch_name_raises(
@@ -1319,7 +1319,7 @@ class TestMetricDefinition:
                     },
                     "{{parameters.param}}",
                 ],
-                "1 AND e.branch_name = 'branch_1'",
+                'CASE e.branch WHEN "branch_1" THEN "1"',
             ),
             (
                 [
@@ -1336,8 +1336,8 @@ class TestMetricDefinition:
                     "COUNTIF(id = {{parameters.param}})",
                 ],
                 (
-                    "COUNTIF(id = 1 AND e.branch_name = 'branch_1') "
-                    "OR COUNTIF(id = 2 AND e.branch_name = 'branch_2')"
+                    """COUNTIF(id = CASE e.branch """
+                    """WHEN "branch_1" THEN "1" WHEN "branch_2" THEN "2")"""
                 ),
             ),
         ),


### PR DESCRIPTION
# Fear(cirrus-753): parametise outcome spotlight multi message id part 2 

Follow up to #1200 which had to be reverted due to validation check failing for `jetstream-config` repo as the result of the change.

Commit: 132cc36f089c5c8b47ed18afa98936b79625cc19 should resolve the validation error.