### PR TITLE
fix #1333: move log export into a finally block

### DIFF
--- a/jetstream/export_json.py
+++ b/jetstream/export_json.py
@@ -219,7 +219,7 @@ def export_experiment_logs(
     )
 
     log_text = f"Got {num_logs} logs for experiment {experiment_slug}"
-    log_text += f" (newer than {analysis_start_time}" if analysis_start_time is not None else ""
+    log_text += f" (newer than {analysis_start_time})" if analysis_start_time is not None else ""
     logger.info(log_text)
 
     if experiment_logs is not None:

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -388,6 +388,7 @@ class TestAnalysisExecutor:
 class TestSerialExecutorStrategy:
     def test_trivial_workflow(self, monkeypatch):
         monkeypatch.setattr("jetstream.cli.export_metadata", Mock())
+        monkeypatch.setattr("jetstream.cli.export_experiment_logs", Mock())
         fake_analysis = Mock()
         strategy = cli.SerialExecutorStrategy(
             project_id="spam",
@@ -402,6 +403,7 @@ class TestSerialExecutorStrategy:
 
     def test_simple_workflow(self, cli_experiments, monkeypatch):
         monkeypatch.setattr("jetstream.cli.export_metadata", Mock())
+        monkeypatch.setattr("jetstream.cli.export_experiment_logs", Mock())
         fake_analysis = Mock()
         experiment = cli_experiments.experiments[0]
         spec = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs)


### PR DESCRIPTION
The log export only occurs right now if analysis succeeds, so we move it into a `finally` block to ensure we export logs in case of error during analysis.