### PR TITLE
fix #1336: floor timestamp filter to nearest minute

### DIFF
--- a/jetstream/export_json.py
+++ b/jetstream/export_json.py
@@ -164,7 +164,8 @@ def _get_experiment_logs_as_json(
         WHERE experiment = '{experiment_slug}'
     """
     if min_timestamp is not None:
-        query_text += f" AND timestamp >= '{min_timestamp}'"
+        floored_timestamp = min_timestamp.replace(second=0, microsecond=0)
+        query_text += f" AND timestamp >= TIMESTAMP('{floored_timestamp}')"
 
     query_text += " ORDER BY timestamp ASC"
 


### PR DESCRIPTION
Round down the timestamp filter to the nearest minute, which should help with catching the logs that occur in the same second as the analysis run starts (because the logs table only records to nearest second so the previous microsecond filter was too precise). Also make the TIMESTAMP cast explicit.