### PR TITLE
fix #1436: export errors in current weekly analysis window

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -180,6 +180,7 @@ class SerialExecutorStrategy:
                     log_dataset,
                     log_table,
                     analysis.start_time,
+                    config.experiment.enrollment_end_date,
                     self.log_config,
                 )
         return not failed
@@ -720,6 +721,7 @@ def export_experiment_logs_to_json(
         log_dataset_id,
         log_table_id,
         date,
+        None,
         ctx.obj["log_config"],
     )
 


### PR DESCRIPTION
Because there may be errors computing weekly analysis, and weekly analysis is only computed once per week, these errors will be aged out of the current export date range (`> analysis_start_time`).

This PR uses the experiment's `enrollment_end_date` to calculate the end of the last weekly analysis window, and uses that timestamp for the error log export filter.