### PR TITLE
fix config datasource test by getting specific config

### DIFF
--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -39,8 +39,16 @@ class TestConfigLoader:
         assert ConfigLoader.get_outcome("non_existing", "foo") is None
 
     def test_get_data_source(self):
-        metric = list(ConfigLoader.configs.definitions[0].spec.metrics.definitions.values())[0]
-        platform = ConfigLoader.configs.definitions[0].platform
+        config_definition = next(
+            (
+                config
+                for config in ConfigLoader.configs.definitions
+                if config.slug == "firefox_desktop"
+            ),
+            None,
+        )
+        metric = list(config_definition.spec.metrics.definitions.values())[0]
+        platform = config_definition.platform
         assert ConfigLoader.get_data_source(metric.data_source.name, platform) is not None
 
     def test_get_nonexisting_data_source(self):


### PR DESCRIPTION
I was seeing a local issue with this test where it was retrieving a config with no metrics, causing the test to fail. This change forces the test to get a specific config by slug.