### PR TITLE
fix #1298: assume multiple analysis_bases and export all results

### DIFF
--- a/jetstream/export_json.py
+++ b/jetstream/export_json.py
@@ -66,7 +66,6 @@ def _export_table(
         f"""
         SELECT *
         FROM {dataset_id}.{table}
-        WHERE analysis_basis = 'enrollments'
     """
     )  # todo: once experimenter supports different analysis_bases, remove filter
 

--- a/jetstream/export_json.py
+++ b/jetstream/export_json.py
@@ -67,7 +67,7 @@ def _export_table(
         SELECT *
         FROM {dataset_id}.{table}
     """
-    )  # todo: once experimenter supports different analysis_bases, remove filter
+    )
 
     job.result()
 

--- a/jetstream/metric.py
+++ b/jetstream/metric.py
@@ -15,11 +15,6 @@ class Metric(parser_metric.Metric):
     metadata required for analysis.
     """
 
-    def __attrs_post_init__(self):
-        # Print warning if exposures is used
-        if parser_metric.AnalysisBasis.EXPOSURES in self.analysis_bases:
-            print(f"Using exposures analysis basis for {self.name}. Not supported in Experimenter")
-
     def to_mozanalysis_metric(self) -> mozanalysis.metrics.Metric:
         """Return Jetstream metric as mozanalysis metric."""
         return mozanalysis.metrics.Metric(
@@ -43,7 +38,8 @@ class Metric(parser_metric.Metric):
         cls,
         mozanalysis_metric: mozanalysis.metrics.Metric,
         analysis_bases: Optional[List[parser_metric.AnalysisBasis]] = [
-            parser_metric.AnalysisBasis.ENROLLMENTS
+            parser_metric.AnalysisBasis.ENROLLMENTS,
+            parser_metric.AnalysisBasis.EXPOSURES,
         ],
     ) -> "Metric":
         return cls(
@@ -60,7 +56,8 @@ class Metric(parser_metric.Metric):
             friendly_name=mozanalysis_metric.friendly_name,
             description=mozanalysis_metric.description,
             bigger_is_better=mozanalysis_metric.bigger_is_better,
-            analysis_bases=analysis_bases or [parser_metric.AnalysisBasis.ENROLLMENTS],
+            analysis_bases=analysis_bases
+            or [parser_metric.AnalysisBasis.ENROLLMENTS, parser_metric.AnalysisBasis.EXPOSURES],
         )
 
     @classmethod

--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from unittest.mock import Mock
 
 import pytest
 import pytz
@@ -12,11 +11,6 @@ def pytest_addoption(parser):
         action="store_true",
         help="Run integration tests",
     )
-
-
-@pytest.fixture(autouse=True)
-def setup(monkeypatch):
-    monkeypatch.setattr("jetstream.metric.Metric.__attrs_post_init__", Mock())
 
 
 @pytest.fixture

--- a/jetstream/tests/data/test_events.ndjson
+++ b/jetstream/tests/data/test_events.ndjson
@@ -1,5 +1,7 @@
 {"submission_date": "2020-04-02", "client_id": "aaaa", "event_category": "normandy", "event_method": "enroll", "event_string_value": "test-experiment", "event_map_values": [{"key": "branch", "value": "branch1"}]}
 {"submission_date": "2020-04-03", "client_id": "bbbb", "event_category": "normandy", "event_method": "enroll", "event_string_value": "test-experiment", "event_map_values": [{"key": "branch", "value": "branch2"}]}
+{"submission_date": "2020-04-02", "client_id": "aaaa", "event_category": "normandy", "event_method": "exposure", "event_string_value": "test-experiment", "event_map_values": [{"key": "branch", "value": "branch1"}]}
+{"submission_date": "2020-04-03", "client_id": "bbbb", "event_category": "normandy", "event_method": "exposure", "event_string_value": "test-experiment", "event_map_values": [{"key": "branch", "value": "branch2"}]}
 {"submission_date": "2020-04-03", "client_id": "bbbb", "event_category": "foo"}
 {"submission_date": "2020-04-03", "client_id": "cccc", "event_category": "foo", "event_method": "enroll", "event_string_value": "test-experiment", "event_map_values": [{"key": "branch", "value": "branch1"}]}
 {"submission_date": "2020-04-03", "client_id": "dddd", "event_category": "foo", "event_method": "enroll", "event_string_value": "test-experiment", "event_map_values": [{"key": "branch", "value": "branch2"}]}

--- a/jetstream/tests/integration/conftest.py
+++ b/jetstream/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 import random
 import string
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 from google.api_core.exceptions import NotFound
@@ -17,11 +16,6 @@ def pytest_runtest_setup(item):
         return
     if not item.config.getoption("--integration", False):
         pytest.skip("Skipping integration test")
-
-
-@pytest.fixture(autouse=True)
-def setup(monkeypatch):
-    monkeypatch.setattr("jetstream.metric.Metric.__attrs_post_init__", Mock())
 
 
 @pytest.fixture

--- a/jetstream/tests/test_metric.py
+++ b/jetstream/tests/test_metric.py
@@ -25,4 +25,4 @@ class TestMetric:
 
         assert metric
         assert metric.name == "uri_count"
-        assert metric.analysis_bases == [AnalysisBasis.ENROLLMENTS]
+        assert metric.analysis_bases == [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES]


### PR DESCRIPTION
This adds some checks for multiple analysis bases (for now this defaults to `enrollments`, `exposures`) and removes some assumptions we previously wanted when only `enrollments` were supported.