### PR TITLE
fix #1510: sub-filter segment data properly

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -335,11 +335,11 @@ class Analysis:
 
         if (
             analysis_basis == AnalysisBasis.ENROLLMENTS
-            and "enrollment_date" in metrics_data.columns
+            and "enrollment_date" in segment_data.columns
         ):
-            segment_data = metrics_data[metrics_data["enrollment_date"].notnull()]
-        elif analysis_basis == AnalysisBasis.EXPOSURES and "exposure_date" in metrics_data.columns:
-            segment_data = metrics_data[metrics_data["exposure_date"].notnull()]
+            segment_data = segment_data[segment_data["enrollment_date"].notnull()]
+        elif analysis_basis == AnalysisBasis.EXPOSURES and "exposure_date" in segment_data.columns:
+            segment_data = segment_data[segment_data["exposure_date"].notnull()]
 
         return segment_data
 


### PR DESCRIPTION
When adding support for multiple analysis bases, there was a regression introduced for segments. This fixes that regression. The function affected filters data to a given segment, and then filters the segment data to a given analysis_basis.