### PR TITLE
Load configs from metric hub

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -36,13 +36,7 @@ from . import bq_normalize_name
 from .analysis import Analysis
 from .argo import submit_workflow
 from .bigquery_client import BigQueryClient
-from .config import (
-    DEFAULT_CONFIG_REPO,
-    METRIC_HUB_REPO,
-    ConfigLoader,
-    _ConfigLoader,
-    validate,
-)
+from .config import CONFIGS, METRIC_HUB_REPO, ConfigLoader, _ConfigLoader, validate
 from .dryrun import DryRunFailedError
 from .errors import ExplicitSkipException, ValidationException
 from .experimenter import ExperimentCollection
@@ -527,7 +521,7 @@ config_repos_option = click.option(
     "--config-repos",
     help="URLs to public repos with configs",
     multiple=True,
-    default=[METRIC_HUB_REPO, DEFAULT_CONFIG_REPO],
+    default=[METRIC_HUB_REPO, CONFIGS],
 )
 private_config_repos_option = click.option(
     "--private_config_repos",

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -37,8 +37,8 @@ from pytz import UTC
 
 from . import bq_normalize_name
 
-DEFAULT_CONFIG_REPO = "https://github.com/mozilla/jetstream-config"
 METRIC_HUB_REPO = "https://github.com/mozilla/metric-hub"
+CONFIGS = "https://github.com/mozilla/metric-hub/tree/main/jetstream"
 
 
 class _ConfigLoader:
@@ -57,9 +57,7 @@ class _ConfigLoader:
             return configs
 
         if self.config_collection is None:
-            self.config_collection = ConfigCollection.from_github_repos(
-                [METRIC_HUB_REPO, DEFAULT_CONFIG_REPO]
-            )
+            self.config_collection = ConfigCollection.from_github_repos([METRIC_HUB_REPO, CONFIGS])
         self._configs = self.config_collection
         return self._configs
 

--- a/jetstream/metadata.py
+++ b/jetstream/metadata.py
@@ -9,7 +9,7 @@ import google.cloud.storage as storage
 from metric_config_parser.analysis import AnalysisConfiguration
 
 from jetstream import bq_normalize_name
-from jetstream.config import DEFAULT_CONFIG_REPO, ConfigLoader
+from jetstream.config import METRIC_HUB_REPO, ConfigLoader
 from jetstream.statistics import StatisticResult
 
 logger = logging.getLogger(__name__)
@@ -113,7 +113,10 @@ class ExperimentMetadata:
                 != config.experiment.experiment.proposed_enrollment
                 else None,
                 skip=config.experiment.skip,
-                url=DEFAULT_CONFIG_REPO + "/blob/main/" + config.experiment.normandy_slug + ".toml",
+                url=METRIC_HUB_REPO
+                + "/blob/main/jetstream/"
+                + config.experiment.normandy_slug
+                + ".toml",
             )
 
         return cls(

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -19,7 +19,7 @@ class TestConfigLoader:
     def test_configs_from(self):
         loader = _ConfigLoader()
         configs_collection = loader.with_configs_from(
-            ["https://github.com/mozilla/jetstream-config"]
+            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
         )
         assert configs_collection.configs is not None
         assert len(configs_collection.configs.configs) == len(loader.configs.configs)

--- a/jetstream/tests/test_metadata.py
+++ b/jetstream/tests/test_metadata.py
@@ -14,7 +14,7 @@ from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.config import Outcome
 from metric_config_parser.outcome import OutcomeSpec
 
-from jetstream.config import DEFAULT_CONFIG_REPO, ConfigLoader, _ConfigLoader
+from jetstream.config import METRIC_HUB_REPO, ConfigLoader, _ConfigLoader
 from jetstream.metadata import ExperimentMetadata, export_metadata
 from jetstream.statistics import StatisticResult
 
@@ -77,7 +77,8 @@ def test_metadata_reference_branch(mock_get, experiments):
 
     assert metadata.external_config.reference_branch == "a"
     assert (
-        metadata.external_config.url == DEFAULT_CONFIG_REPO + "/blob/main/normandy-test-slug.toml"
+        metadata.external_config.url
+        == METRIC_HUB_REPO + "/blob/main/jetstream/normandy-test-slug.toml"
     )
 
     config_str = dedent(
@@ -265,7 +266,7 @@ def test_export_metadata(mock_storage_client, experiments):
                 "skip": false,
                 "start_date": null,
                 "url": """
-        + '"https://github.com/mozilla/jetstream-config/blob/main/normandy-test-slug.toml"'
+        + '"https://github.com/mozilla/metric-hub/blob/main/jetstream/normandy-test-slug.toml"'
         + r"""},
             "analysis_start_time": """
         + f'"{mock_analysis_start}"'


### PR DESCRIPTION
Depends on https://github.com/mozilla/metric-config-parser/pull/148
Blocked by actually moving configs into metric-hub

For https://github.com/mozilla/jetstream/issues/1527