### PR TITLE
move analysis_period_length to parent PreTreatment

### DIFF
--- a/jetstream/pre_treatment.py
+++ b/jetstream/pre_treatment.py
@@ -15,6 +15,8 @@ class PreTreatment(ABC):
     calculating statistics.
     """
 
+    analysis_period_length: int = 1
+
     @classmethod
     def name(cls):
         """Return snake-cased name of the statistic."""
@@ -96,8 +98,6 @@ class CensorValuesAboveThreshold(PreTreatment):
 @attr.s(auto_attribs=True)
 class NormalizeOverAnalysisPeriod(PreTreatment):
     """Normalizes the row values over a given analysis period (number of days)."""
-
-    analysis_period_length: int = 1
 
     def apply(self, df: DataFrame, col: str) -> DataFrame:
         df[col] = df[col] / self.analysis_period_length

--- a/jetstream/pre_treatment.py
+++ b/jetstream/pre_treatment.py
@@ -15,7 +15,7 @@ class PreTreatment(ABC):
     calculating statistics.
     """
 
-    analysis_period_length: int = 1
+    analysis_period_length: int = attr.ib(kw_only=True, default=1)
 
     @classmethod
     def name(cls):
@@ -98,6 +98,8 @@ class CensorValuesAboveThreshold(PreTreatment):
 @attr.s(auto_attribs=True)
 class NormalizeOverAnalysisPeriod(PreTreatment):
     """Normalizes the row values over a given analysis period (number of days)."""
+
+    analysis_period_length: int = 1
 
     def apply(self, df: DataFrame, col: str) -> DataFrame:
         df[col] = df[col] / self.analysis_period_length

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -70,7 +70,7 @@ class Summary:
                 if pre_treatment.name() == pre_treatment_conf.name:
                     found = True
                     # inject analysis_period_length from experiment
-                    pre_treatment_conf.args["analysis_period_length"] = analysis_period_length
+                    pre_treatment.analysis_period_length = analysis_period_length or 1
 
                     pre_treatments.append(pre_treatment.from_dict(pre_treatment_conf.args))
 

--- a/jetstream/tests/test_pretreatment.py
+++ b/jetstream/tests/test_pretreatment.py
@@ -74,3 +74,11 @@ class TestPreTreatment:
         ex1 = pt.apply(example_data, "a")
         assert ex1.loc[1, "a"] == 0
         assert np.isnan(ex1.loc[1, "b"])
+
+    def test_normalize_analysis_perioby_d(self, example_data):
+        pt = pre_treatment.NormalizeOverAnalysisPeriod(analysis_period_length=10)
+        ex1 = pt.apply(example_data, "a")
+        assert ex1.loc[0, "a"] == 1 / 10
+        assert ex1.loc[0, "b"] == 2
+        assert ex1.loc[2, "a"] == 1 / 2
+        assert ex1.loc[2, "b"] == 7


### PR DESCRIPTION
We are adding the `analysis_period_length` to all pre-treatments during analysis because they need to come in dynamically and this removes the need for a more complicated workflow. However, this also means the `analysis_period_length` needs to exist on all pre-treatments even if it is not explicitly used. This PR moves the class field to the parent PreTreatment.