### PR TITLE
Use analysis_period default string values in Argo workflow

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -135,16 +135,16 @@ class ArgoExecutorStrategy:
                 "bucket": self.bucket,
                 "analysis_periods_day": "day"
                 if AnalysisPeriod.DAY in self.analysis_periods
-                else analysis_period_default,
+                else analysis_period_default.value,
                 "analysis_periods_week": "week"
                 if AnalysisPeriod.WEEK in self.analysis_periods
-                else analysis_period_default,
+                else analysis_period_default.value,
                 "analysis_periods_days28": "days28"
                 if AnalysisPeriod.DAYS_28 in self.analysis_periods
-                else analysis_period_default,
+                else analysis_period_default.value,
                 "analysis_periods_overall": "overall"
                 if AnalysisPeriod.OVERALL in self.analysis_periods
-                else analysis_period_default,
+                else analysis_period_default.value,
             },
             monitor_status=self.monitor_status,
             cluster_ip=self.cluster_ip,


### PR DESCRIPTION
Fixes the following issue on argo:

```
Usage: jetstream run [OPTIONS]
Try ‘jetstream run --help’ for help.
Error: Invalid value for ‘--analysis_periods’ / ‘--analysis-periods’: AnalysisPeriod.OVERALL
time=“2023-05-08T22:34:49 UTC” level=info msg=“sub-process exited” argo=true error=“<nil>”
Error: exit status 2
```