### PR TITLE
fix #1745: ensure enrollment is not overridden before checking api flag

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -540,9 +540,16 @@ class Analysis:
         self.check_runnable(current_date)
         assert self.config.experiment.start_date is not None  # for mypy
 
+        # make sure enrollment is actually ended (and enrollment is not manually overridden)
         if (
             hasattr(self.config.experiment, "is_enrollment_paused")
             and self.config.experiment.is_enrollment_paused is False
+        ) and (
+            self.config.experiment.proposed_enrollment
+            == self.config.experiment.experiment.proposed_enrollment
+            and self.config.experiment.enrollment_end_date
+            == self.config.experiment.experiment.enrollment_end_date
+            and self.config.experiment.experiment_spec.enrollment_period is None
         ):
             raise errors.EnrollmentNotCompleteException(self.config.experiment.normandy_slug)
 

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -287,6 +287,24 @@ def test_skip_while_enrolling(experiments):
         )
 
 
+def test_custom_override_skips_enrollment_paused_check(experiments, monkeypatch):
+    conf = dedent(
+        """
+        [experiment]
+        enrollment_period = 7
+        """
+    )
+    spec = AnalysisSpec.from_dict(toml.loads(conf))
+    config = spec.resolve(experiments[8], ConfigLoader.configs)
+    m = Mock()
+    m.return_value = None
+    monkeypatch.setattr("jetstream.analysis.Analysis._get_timelimits_if_ready", m)
+    # no errors expected
+    Analysis("test", "test", config).run(
+        current_date=dt.datetime(2020, 1, 1, tzinfo=pytz.utc), dry_run=True
+    )
+
+
 def test_validation_working_while_enrolling(experiments):
     config = AnalysisSpec().resolve(experiments[8], ConfigLoader.configs)
     assert experiments[8].is_enrollment_paused is False


### PR DESCRIPTION
Ignore the `is_enrollment_paused` flag if the enrollment period is overridden via custom config.