### PR TITLE
fix #1809: migrate duplicative schemas to new package

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -692,12 +692,6 @@ class Analysis:
                             analysis_length_dates,
                         )
 
-                    print(
-                        f"""
-                        COUNTS ANALYSIS BASIS {analysis_basis}
-                        ({type(analysis_basis)} from {analysis_basis.__module__})
-                        """
-                    )
                     segment_results.__root__ += self.counts(segment_data, segment, analysis_basis)
 
             results.append(

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -341,7 +341,7 @@ class Analysis:
                     analysis_basis=analysis_basis,
                 )
                 for b in self.config.experiment.branches
-                if b.slug not in {c["branch"] for c in counts}
+                if b.slug not in {c["branch"] for c in counts.__root__}
             ]
         )
 
@@ -358,11 +358,11 @@ class Analysis:
             segment_data = metrics_data
 
         if (
-            analysis_basis == AnalysisBasis.enrollments
+            analysis_basis == AnalysisBasis.ENROLLMENTS
             and "enrollment_date" in segment_data.columns
         ):
             segment_data = segment_data[segment_data["enrollment_date"].notnull()]
-        elif analysis_basis == AnalysisBasis.exposures and "exposure_date" in segment_data.columns:
+        elif analysis_basis == AnalysisBasis.EXPOSURES and "exposure_date" in segment_data.columns:
             segment_data = segment_data[segment_data["exposure_date"].notnull()]
 
         return segment_data
@@ -475,7 +475,7 @@ class Analysis:
         print(enrollments_sql)
 
         metrics_sql = exp.build_metrics_query(
-            metrics, limits, "enrollments_table", AnalysisBasis.enrollments
+            metrics, limits, "enrollments_table", AnalysisBasis.ENROLLMENTS
         )
 
         # enrollments_table doesn't get created when performing a dry run;
@@ -692,7 +692,12 @@ class Analysis:
                             analysis_length_dates,
                         )
 
-                    print(f"COUNTS ANALYSIS BASIS {analysis_basis} ({type(analysis_basis)})")
+                    print(
+                        f"""
+                        COUNTS ANALYSIS BASIS {analysis_basis}
+                        ({type(analysis_basis)} from {analysis_basis.__module__})
+                        """
+                    )
                     segment_results.__root__ += self.counts(segment_data, segment, analysis_basis)
 
             results.append(

--- a/jetstream/metric.py
+++ b/jetstream/metric.py
@@ -39,8 +39,8 @@ class Metric(parser_metric.Metric):
         cls,
         mozanalysis_metric: mozanalysis.metrics.Metric,
         analysis_bases: Optional[List[AnalysisBasis]] = [
-            AnalysisBasis.enrollments,
-            AnalysisBasis.exposures,
+            AnalysisBasis.ENROLLMENTS,
+            AnalysisBasis.EXPOSURES,
         ],
     ) -> "Metric":
         return cls(
@@ -57,7 +57,7 @@ class Metric(parser_metric.Metric):
             friendly_name=mozanalysis_metric.friendly_name,
             description=mozanalysis_metric.description,
             bigger_is_better=mozanalysis_metric.bigger_is_better,
-            analysis_bases=analysis_bases or [AnalysisBasis.enrollments, AnalysisBasis.exposures],
+            analysis_bases=analysis_bases or [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES],
         )
 
     @classmethod

--- a/jetstream/metric.py
+++ b/jetstream/metric.py
@@ -5,6 +5,7 @@ import mozanalysis.experiment
 import mozanalysis.metrics
 from metric_config_parser import data_source
 from metric_config_parser import metric as parser_metric
+from mozilla_nimbus_schemas.jetstream import AnalysisBasis
 
 
 class Metric(parser_metric.Metric):
@@ -37,9 +38,9 @@ class Metric(parser_metric.Metric):
     def from_mozanalysis_metric(
         cls,
         mozanalysis_metric: mozanalysis.metrics.Metric,
-        analysis_bases: Optional[List[parser_metric.AnalysisBasis]] = [
-            parser_metric.AnalysisBasis.ENROLLMENTS,
-            parser_metric.AnalysisBasis.EXPOSURES,
+        analysis_bases: Optional[List[AnalysisBasis]] = [
+            AnalysisBasis.enrollments,
+            AnalysisBasis.exposures,
         ],
     ) -> "Metric":
         return cls(
@@ -56,8 +57,7 @@ class Metric(parser_metric.Metric):
             friendly_name=mozanalysis_metric.friendly_name,
             description=mozanalysis_metric.description,
             bigger_is_better=mozanalysis_metric.bigger_is_better,
-            analysis_bases=analysis_bases
-            or [parser_metric.AnalysisBasis.ENROLLMENTS, parser_metric.AnalysisBasis.EXPOSURES],
+            analysis_bases=analysis_bases or [AnalysisBasis.enrollments, AnalysisBasis.exposures],
         )
 
     @classmethod

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -6,10 +6,9 @@ import re
 from abc import ABC, abstractmethod
 from decimal import Decimal
 from inspect import isabstract
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import attr
-import cattr
 import mozanalysis.bayesian_stats.bayesian_bootstrap
 import mozanalysis.bayesian_stats.binary
 import mozanalysis.frequentist_stats.bootstrap
@@ -19,7 +18,11 @@ import statsmodels.api as sm
 from google.cloud import bigquery
 from metric_config_parser import metric as parser_metric
 from metric_config_parser.experiment import Experiment
+from mozilla_nimbus_schemas.jetstream import AnalysisBasis
+from mozilla_nimbus_schemas.jetstream import Statistic as StatisticSchema
+from mozilla_nimbus_schemas.jetstream import Statistics as StatisticsSchema
 from pandas import DataFrame, Series
+from pydantic import validator
 from statsmodels.distributions.empirical_distribution import ECDF
 
 from .errors import StatisticComputationException
@@ -29,19 +32,13 @@ from .pre_treatment import PreTreatment
 logger = logging.getLogger(__name__)
 
 
-def _maybe_decimal(value) -> Optional[Decimal]:
-    if value is None:
-        return None
-    return Decimal(value)
-
-
 @attr.s(auto_attribs=True)
 class Summary:
     """Represents a metric with a statistical treatment."""
 
     metric: Metric
     statistic: "Statistic"
-    pre_treatments: List[PreTreatment] = attr.Factory(list)
+    pre_treatments: list[PreTreatment] = attr.Factory(list)
 
     @classmethod
     def from_config(
@@ -87,7 +84,7 @@ class Summary:
         self,
         data: DataFrame,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> "StatisticResultCollection":
         """Apply the statistic transformation for data related to the specified metric."""
@@ -97,35 +94,19 @@ class Summary:
         return self.statistic.apply(data, self.metric.name, experiment, analysis_basis, segment)
 
 
-@attr.s(auto_attribs=True, kw_only=True)
-class StatisticResult:
+class StatisticResult(StatisticSchema):
     """
     Represents the resulting data after applying a statistic transformation
     to metric data.
     """
 
-    SCHEMA_VERSION = 4
+    _schema_version = 4
 
-    metric: str
-    statistic: str
-    branch: str
-    parameter: Optional[Decimal] = attr.ib(converter=_maybe_decimal, default=None)
-    comparison: Optional[str] = None
-    comparison_to_branch: Optional[str] = None
-    ci_width: Optional[float] = None
-    point: Optional[float] = None
-    lower: Optional[float] = None
-    upper: Optional[float] = None
-    segment: Optional[str] = None
-    analysis_basis: Optional[str] = None
-
-    def __attrs_post_init__(self):
-        for k in ("ci_width", "point", "lower", "upper"):
-            v = getattr(self, k)
-            if v is None:
-                continue
-            if not isinstance(v, numbers.Number):
-                raise ValueError(f"Expected a number for {k}; got {repr(v)}")
+    @validator("ci_width", "point", "lower", "upper", allow_reuse=True)
+    def check_number_fields(cls, v, values, field):
+        if v is not None and not isinstance(v, numbers.Number):
+            raise ValueError(f"Expected a number for {field.name}; got {repr(v)}")
+        return v
 
     bq_schema = (
         bigquery.SchemaField("metric", "STRING"),
@@ -142,38 +123,45 @@ class StatisticResult:
         bigquery.SchemaField("analysis_basis", "STRING"),
     )
 
+    # we want a class method that is also a property
+    # - this is supported in python 3.9 and 3.10 but
+    #   is *deprecated in python 3.11*
+    # - mypy does not support this stacking of decorators
+    #   so we ignore it here
+    @classmethod  # type: ignore[misc]
+    @property
+    def SCHEMA_VERSION(cls) -> int:
+        return cls._schema_version
 
-@attr.s(auto_attribs=True)
-class StatisticResultCollection:
+
+class StatisticResultCollection(StatisticsSchema):
     """
     Represents a set of statistics result data.
     """
 
-    data: List[StatisticResult] = attr.Factory(list)
+    __root__: list[StatisticResult] = []
 
-    converter = cattr.BaseConverter()
-    _normalize_decimal: Callable[[Decimal], str] = lambda x: str(round(x, 6).normalize())
-    converter.register_unstructure_hook(Decimal, _normalize_decimal)
-    _suppress_infinites: Callable[[float], Optional[float]] = (
-        lambda x: x if math.isfinite(x) else None
-    )
-    converter.register_unstructure_hook(float, _suppress_infinites)
+    @validator("*")
+    def normalize_decimal(cls, v):
+        if isinstance(v, Decimal):
+            return str(round(v, 6).normalize())
+        return v
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Return statistic results as dict."""
-        return self.converter.unstructure(self)
+    @validator("*")
+    def suppress_infinites(cls, v):
+        if not isinstance(v, float) or math.isfinite(v):
+            return v
+        return None
 
     def set_segment(self, segment: str) -> "StatisticResultCollection":
         """Sets the `segment` field in-place on all children."""
-        for result in self.data:
+        for result in self.__root__:
             result.segment = segment
         return self
 
-    def set_analysis_basis(
-        self, analysis_basis: parser_metric.AnalysisBasis
-    ) -> "StatisticResultCollection":
+    def set_analysis_basis(self, analysis_basis: AnalysisBasis) -> "StatisticResultCollection":
         """Sets the `analysis_basis` field in-place on all children."""
-        for result in self.data:
+        for result in self.__root__:
             result.analysis_basis = analysis_basis.value
         return self
 
@@ -200,7 +188,7 @@ class Statistic(ABC):
         df: DataFrame,
         metric: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> "StatisticResultCollection":
         """
@@ -208,7 +196,7 @@ class Statistic(ABC):
         of statistic results.
         """
 
-        statistic_result_collection = StatisticResultCollection([])
+        statistic_result_collection = StatisticResultCollection.parse_obj([])
 
         if metric in df:
             branch_list = df.branch.unique()
@@ -232,9 +220,11 @@ class Statistic(ABC):
 
                 for ref_branch in ref_branch_list:
                     try:
-                        statistic_result_collection.data += self.transform(
-                            df, metric, ref_branch, experiment, analysis_basis, segment
-                        ).data
+                        statistic_result_collection.__root__.extend(
+                            self.transform(
+                                df, metric, ref_branch, experiment, analysis_basis, segment
+                            ).__root__
+                        )
                     except Exception as e:
                         logger.exception(
                             f"Error while computing statistic {self.name()} "
@@ -263,13 +253,13 @@ class Statistic(ABC):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> "StatisticResultCollection":
         return NotImplemented
 
     @classmethod
-    def from_dict(cls, config_dict: Dict[str, Any]):
+    def from_dict(cls, config_dict: dict[str, Any]):
         """Create a class instance with the specified config parameters."""
         return cls(**config_dict)  # type: ignore
 
@@ -353,7 +343,7 @@ def flatten_simple_compare_branches_result(
             )
         )
 
-    return StatisticResultCollection(statlist)
+    return StatisticResultCollection.parse_obj(statlist)
 
 
 @attr.s(auto_attribs=True)
@@ -368,7 +358,7 @@ class BootstrapMean(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
         critical_point = (1 - self.confidence_interval) / 2
@@ -402,7 +392,7 @@ class Binomial(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
         critical_point = (1 - self.confidence_interval) / 2
@@ -446,10 +436,10 @@ class Deciles(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
-        stats_results = StatisticResultCollection([])
+        stats_results = StatisticResultCollection.parse_obj([])
 
         critical_point = (1 - self.confidence_interval) / 2
         summary_quantiles = (critical_point, 1 - critical_point)
@@ -467,7 +457,7 @@ class Deciles(Statistic):
         for branch, branch_result in ma_result["individual"].items():
             for param, decile_result in branch_result.iterrows():
                 lower, upper = _extract_ci(decile_result, critical_point)
-                stats_results.data.append(
+                stats_results.__root__.append(
                     StatisticResult(
                         metric=metric,
                         statistic="deciles",
@@ -486,7 +476,7 @@ class Deciles(Statistic):
             abs_uplift = branch_result["abs_uplift"]
             for param, decile_result in abs_uplift.iterrows():
                 lower_abs, upper_abs = _extract_ci(decile_result, critical_point)
-                stats_results.data.append(
+                stats_results.__root__.append(
                     StatisticResult(
                         metric=metric,
                         statistic="deciles",
@@ -506,7 +496,7 @@ class Deciles(Statistic):
             rel_uplift = branch_result["rel_uplift"]
             for param, decile_result in rel_uplift.iterrows():
                 lower_rel, upper_rel = _extract_ci(decile_result, critical_point)
-                stats_results.data.append(
+                stats_results.__root__.append(
                     StatisticResult(
                         metric=metric,
                         statistic="deciles",
@@ -532,7 +522,7 @@ class Count(Statistic):
         df: DataFrame,
         metric: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ):
         return self.transform(
@@ -550,7 +540,7 @@ class Count(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
         results = []
@@ -572,7 +562,7 @@ class Count(Statistic):
                     segment=segment,
                 )
             )
-        return StatisticResultCollection(results)
+        return StatisticResultCollection.parse_obj(results)
 
 
 class Sum(Statistic):
@@ -581,7 +571,7 @@ class Sum(Statistic):
         df: DataFrame,
         metric: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ):
         return self.transform(
@@ -599,7 +589,7 @@ class Sum(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
         results = []
@@ -621,7 +611,7 @@ class Sum(Statistic):
                     segment=segment,
                 )
             )
-        return StatisticResultCollection(results)
+        return StatisticResultCollection.parse_obj(results)
 
 
 @attr.s(auto_attribs=True)
@@ -665,7 +655,7 @@ class KernelDensityEstimate(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
         results = []
@@ -719,7 +709,7 @@ class KernelDensityEstimate(Statistic):
                         segment=segment,
                     )
                 )
-        return StatisticResultCollection(results)
+        return StatisticResultCollection.parse_obj(results)
 
 
 @attr.s(auto_attribs=True)
@@ -733,7 +723,7 @@ class EmpiricalCDF(Statistic):
         metric: str,
         reference_branch: str,
         experiment: Experiment,
-        analysis_basis: parser_metric.AnalysisBasis,
+        analysis_basis: AnalysisBasis,
         segment: str,
     ) -> StatisticResultCollection:
         results = []
@@ -786,4 +776,4 @@ class EmpiricalCDF(Statistic):
                         segment=segment,
                     )
                 )
-        return StatisticResultCollection(results)
+        return StatisticResultCollection.parse_obj(results)

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -14,7 +14,8 @@ from metric_config_parser.experiment import Branch, Experiment
 from metric_config_parser.metric import AnalysisPeriod, Summary
 from metric_config_parser.segment import Segment, SegmentDataSource
 from metric_config_parser.statistic import Statistic
-from mozanalysis.metrics import AnalysisBasis, agg_sum
+from mozanalysis.metrics import agg_sum
+from mozilla_nimbus_schemas.jetstream import AnalysisBasis
 
 from jetstream.analysis import Analysis
 from jetstream.config import ConfigLoader

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -217,14 +217,14 @@ def test_subset_to_segment(experiments):
         columns=["regular_users_v3", "enrollment_date", "exposure_date"],
     )
     analysis = Analysis("test", "test", configured)
-    all_enrollments = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.enrollments)
+    all_enrollments = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.ENROLLMENTS)
     all_enrollments = all_enrollments.compute()
     assert len(all_enrollments) == 3
     assert len(all_enrollments[all_enrollments["regular_users_v3"] == True]) == 2  # noqa: E712
     assert len(all_enrollments[all_enrollments["regular_users_v3"] == False]) == 0  # noqa: E712
     assert len(all_enrollments[all_enrollments["enrollment_date"] == "1"]) == 3
 
-    all_exposures = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.exposures)
+    all_exposures = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.EXPOSURES)
     all_exposures = all_exposures.compute()
     assert len(all_exposures) == 3
     assert len(all_exposures[all_exposures["regular_users_v3"] == True]) == 1  # noqa: E712
@@ -232,7 +232,7 @@ def test_subset_to_segment(experiments):
     assert len(all_exposures[all_exposures["exposure_date"] == "1"]) == 3
 
     segment_enrollments = analysis.subset_to_segment(
-        "regular_users_v3", metrics_data, AnalysisBasis.enrollments
+        "regular_users_v3", metrics_data, AnalysisBasis.ENROLLMENTS
     )
     segment_enrollments = segment_enrollments.compute()
     assert len(segment_enrollments) == 2
@@ -246,7 +246,7 @@ def test_subset_to_segment(experiments):
     assert len(segment_enrollments[segment_enrollments["enrollment_date"] == "1"]) == 2
 
     segment_exposures = analysis.subset_to_segment(
-        "regular_users_v3", metrics_data, AnalysisBasis.exposures
+        "regular_users_v3", metrics_data, AnalysisBasis.EXPOSURES
     )
     segment_exposures = segment_exposures.compute()
     assert len(segment_exposures) == 1

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -11,7 +11,8 @@ import pytz
 import toml
 from metric_config_parser import segment
 from metric_config_parser.analysis import AnalysisSpec
-from metric_config_parser.metric import AnalysisBasis, AnalysisPeriod
+from metric_config_parser.metric import AnalysisPeriod
+from mozilla_nimbus_schemas.jetstream import AnalysisBasis
 
 import jetstream.analysis
 from jetstream.analysis import Analysis
@@ -216,14 +217,14 @@ def test_subset_to_segment(experiments):
         columns=["regular_users_v3", "enrollment_date", "exposure_date"],
     )
     analysis = Analysis("test", "test", configured)
-    all_enrollments = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.ENROLLMENTS)
+    all_enrollments = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.enrollments)
     all_enrollments = all_enrollments.compute()
     assert len(all_enrollments) == 3
     assert len(all_enrollments[all_enrollments["regular_users_v3"] == True]) == 2  # noqa: E712
     assert len(all_enrollments[all_enrollments["regular_users_v3"] == False]) == 0  # noqa: E712
     assert len(all_enrollments[all_enrollments["enrollment_date"] == "1"]) == 3
 
-    all_exposures = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.EXPOSURES)
+    all_exposures = analysis.subset_to_segment("all", metrics_data, AnalysisBasis.exposures)
     all_exposures = all_exposures.compute()
     assert len(all_exposures) == 3
     assert len(all_exposures[all_exposures["regular_users_v3"] == True]) == 1  # noqa: E712
@@ -231,7 +232,7 @@ def test_subset_to_segment(experiments):
     assert len(all_exposures[all_exposures["exposure_date"] == "1"]) == 3
 
     segment_enrollments = analysis.subset_to_segment(
-        "regular_users_v3", metrics_data, AnalysisBasis.ENROLLMENTS
+        "regular_users_v3", metrics_data, AnalysisBasis.enrollments
     )
     segment_enrollments = segment_enrollments.compute()
     assert len(segment_enrollments) == 2
@@ -245,7 +246,7 @@ def test_subset_to_segment(experiments):
     assert len(segment_enrollments[segment_enrollments["enrollment_date"] == "1"]) == 2
 
     segment_exposures = analysis.subset_to_segment(
-        "regular_users_v3", metrics_data, AnalysisBasis.EXPOSURES
+        "regular_users_v3", metrics_data, AnalysisBasis.exposures
     )
     segment_exposures = segment_exposures.compute()
     assert len(segment_exposures) == 1

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -47,7 +47,14 @@ class TestConfigLoader:
             ),
             None,
         )
-        metric = list(config_definition.spec.metrics.definitions.values())[0]
+        metric = next(
+            (
+                m
+                for m in config_definition.spec.metrics.definitions.values()
+                if m.data_source is not None
+            ),
+            None,
+        )
         platform = config_definition.platform
         assert ConfigLoader.get_data_source(metric.data_source.name, platform) is not None
 

--- a/jetstream/tests/test_metric.py
+++ b/jetstream/tests/test_metric.py
@@ -11,18 +11,18 @@ class TestMetric:
             name="test",
             data_source=DataSource(name="test_data_source", from_expression="test.test"),
             select_expression="test",
-            analysis_bases=[AnalysisBasis.exposures],
+            analysis_bases=[AnalysisBasis.EXPOSURES],
         )
 
         mozanalysis_metric = metric.to_mozanalysis_metric()
 
         assert mozanalysis_metric
         assert mozanalysis_metric.name == metric.name
-        assert metric.analysis_bases == [AnalysisBasis.exposures]
+        assert metric.analysis_bases == [AnalysisBasis.EXPOSURES]
 
     def test_from_mozanalysis_metric(self):
         metric = Metric.from_mozanalysis_metric(uri_count)
 
         assert metric
         assert metric.name == "uri_count"
-        assert metric.analysis_bases == [AnalysisBasis.enrollments, AnalysisBasis.exposures]
+        assert metric.analysis_bases == [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES]

--- a/jetstream/tests/test_metric.py
+++ b/jetstream/tests/test_metric.py
@@ -1,6 +1,6 @@
 from metric_config_parser.data_source import DataSource
-from metric_config_parser.metric import AnalysisBasis
 from mozanalysis.metrics.fenix import uri_count
+from mozilla_nimbus_schemas.jetstream import AnalysisBasis
 
 from jetstream.metric import Metric
 
@@ -11,18 +11,18 @@ class TestMetric:
             name="test",
             data_source=DataSource(name="test_data_source", from_expression="test.test"),
             select_expression="test",
-            analysis_bases=[AnalysisBasis.EXPOSURES],
+            analysis_bases=[AnalysisBasis.exposures],
         )
 
         mozanalysis_metric = metric.to_mozanalysis_metric()
 
         assert mozanalysis_metric
         assert mozanalysis_metric.name == metric.name
-        assert metric.analysis_bases == [AnalysisBasis.EXPOSURES]
+        assert metric.analysis_bases == [AnalysisBasis.exposures]
 
     def test_from_mozanalysis_metric(self):
         metric = Metric.from_mozanalysis_metric(uri_count)
 
         assert metric
         assert metric.name == "uri_count"
-        assert metric.analysis_bases == [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES]
+        assert metric.analysis_bases == [AnalysisBasis.enrollments, AnalysisBasis.exposures]

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -5,8 +5,8 @@ import jsonschema
 import numpy as np
 import pandas as pd
 import pytest
-from metric_config_parser.metric import AnalysisBasis
 from mozanalysis.bayesian_stats.bayesian_bootstrap import get_bootstrap_samples
+from mozilla_nimbus_schemas.jetstream import AnalysisBasis
 
 from jetstream.statistics import (
     Binomial,
@@ -33,11 +33,11 @@ class TestStatistics:
         test_data = pd.DataFrame(
             {"branch": ["treatment"] * 10 + ["control"] * 10, "value": list(range(20))}
         )
-        result = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
-        )
+        results = stat.transform(
+            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+        ).__root__
 
-        branch_results = [r for r in result.data if r.comparison is None]
+        branch_results = [r for r in results if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
         control_result = [r for r in branch_results if r.branch == "control"][0]
         assert treatment_result.point < control_result.point
@@ -51,16 +51,16 @@ class TestStatistics:
                 "value": [False] * 7 + [True] * 3 + [False] * 5 + [True] * 5,
             }
         )
-        result = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
-        )
-        branch_results = [r for r in result.data if r.comparison is None]
+        results = stat.transform(
+            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+        ).__root__
+        branch_results = [r for r in results if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
         control_result = [r for r in branch_results if r.branch == "control"][0]
         assert treatment_result.point < control_result.point
         assert treatment_result.point - 0.7 < 1e-5
 
-        difference = [r for r in result.data if r.comparison == "difference"][0]
+        difference = [r for r in results if r.comparison == "difference"][0]
         assert difference.point - 0.2 < 1e-5
         assert difference.lower and difference.upper
 
@@ -69,12 +69,12 @@ class TestStatistics:
         test_data = pd.DataFrame(
             {"branch": ["treatment"] * 20 + ["control"] * 10, "value": list(range(30))}
         )
-        result = stat.transform(
-            test_data, "identity", "control", None, AnalysisBasis.ENROLLMENTS, "all"
-        ).data
-        assert all(r.metric == "identity" for r in result)
-        assert [r.point for r in result if r.branch == "treatment"] == [20]
-        assert [r.point for r in result if r.branch == "control"] == [10]
+        results = stat.transform(
+            test_data, "identity", "control", None, AnalysisBasis.enrollments, "all"
+        ).__root__
+        assert all(r.metric == "identity" for r in results)
+        assert [r.point for r in results if r.branch == "treatment"] == [20]
+        assert [r.point for r in results if r.branch == "control"] == [10]
 
     def test_sum_int(self):
         stat = Sum()
@@ -86,12 +86,12 @@ class TestStatistics:
                 "value": treatment_values + control_values,
             }
         )
-        result = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
-        ).data
-        assert all(r.metric == "value" for r in result)
-        assert [r.point for r in result if r.branch == "treatment"] == [5]
-        assert [r.point for r in result if r.branch == "control"] == [5]
+        results = stat.transform(
+            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+        ).__root__
+        assert all(r.metric == "value" for r in results)
+        assert [r.point for r in results if r.branch == "treatment"] == [5]
+        assert [r.point for r in results if r.branch == "control"] == [5]
 
     def test_sum_bool(self):
         stat = Sum()
@@ -103,12 +103,12 @@ class TestStatistics:
                 "value": treatment_values + control_values,
             }
         )
-        result = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
-        ).data
-        assert all(r.metric == "value" for r in result)
-        assert [r.point for r in result if r.branch == "treatment"] == [15]
-        assert [r.point for r in result if r.branch == "control"] == [5]
+        results = stat.transform(
+            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+        ).__root__
+        assert all(r.metric == "value" for r in results)
+        assert [r.point for r in results if r.branch == "treatment"] == [15]
+        assert [r.point for r in results if r.branch == "control"] == [5]
 
     def test_binomial_no_reference_branch(self, experiments):
         stat = Binomial()
@@ -123,21 +123,21 @@ class TestStatistics:
                 + [True] * 5,
             }
         )
-        result = stat.apply(test_data, "value", experiments[1], AnalysisBasis.ENROLLMENTS, "all")
+        results = stat.apply(
+            test_data, "value", experiments[1], AnalysisBasis.enrollments, "all"
+        ).__root__
 
-        branch_results = [r for r in result.data if r.comparison is None]
+        branch_results = [r for r in results if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
         control_result = [r for r in branch_results if r.branch == "control"][0]
         assert treatment_result.point < control_result.point
         assert treatment_result.point - 0.7 < 1e-5
 
-        difference = [r for r in result.data if r.comparison == "difference"][0]
+        difference = [r for r in results if r.comparison == "difference"][0]
         assert difference.point - 0.2 < 1e-5
         assert difference.lower and difference.upper
 
-        comparison_branches = [
-            (r.comparison_to_branch, r.branch, r.comparison) for r in result.data
-        ]
+        comparison_branches = [(r.comparison_to_branch, r.branch, r.comparison) for r in results]
         assert (None, "control", None) in comparison_branches
         assert (None, "foo", None) in comparison_branches
         assert (None, "treatment", None) in comparison_branches
@@ -186,39 +186,37 @@ class TestStatistics:
 
     def test_kde(self, wine):
         stat = KernelDensityEstimate()
-        result = stat.transform(wine, "ash", "*", None, AnalysisBasis.ENROLLMENTS, "all").data
-        assert len(result) > 0
+        results = stat.transform(wine, "ash", "*", None, AnalysisBasis.enrollments, "all").__root__
+        assert len(results) > 0
 
     def test_kde_with_geom_zero(self, wine):
         wine = wine.copy()
         wine.loc[0, "ash"] = 0
         stat = KernelDensityEstimate(log_space=True)
-        result = stat.transform(wine, "ash", "*", None, AnalysisBasis.ENROLLMENTS, "all").to_dict()[
-            "data"
-        ]
-        for r in result:
-            assert isinstance(r["point"], float)
-        df = pd.DataFrame(result).astype({"parameter": float})
+        results = stat.transform(wine, "ash", "*", None, AnalysisBasis.enrollments, "all").__root__
+        for r in results:
+            assert isinstance(r.point, float)
+        df = pd.DataFrame([r.dict() for r in results])
         assert df["parameter"].min() == 0
 
     def test_ecdf(self, wine, experiments):
         stat = EmpiricalCDF()
-        result = stat.transform(
-            wine, "ash", "*", experiments[0], AnalysisBasis.ENROLLMENTS, "all"
-        ).data
-        assert len(result) > 0
+        results = stat.transform(
+            wine, "ash", "*", experiments[0], AnalysisBasis.enrollments, "all"
+        ).__root__
+        assert len(results) > 0
 
         logstat = EmpiricalCDF(log_space=True)
-        result = logstat.transform(
-            wine, "ash", "*", experiments[0], AnalysisBasis.ENROLLMENTS, "all"
-        ).data
-        assert len(result) > 0
+        results = logstat.transform(
+            wine, "ash", "*", experiments[0], AnalysisBasis.enrollments, "all"
+        ).__root__
+        assert len(results) > 0
 
         wine["ash"] = -wine["ash"]
-        result = logstat.transform(
-            wine, "ash", "*", experiments[0], AnalysisBasis.ENROLLMENTS, "all"
-        ).data
-        assert len(result) > 0
+        results = logstat.transform(
+            wine, "ash", "*", experiments[0], AnalysisBasis.enrollments, "all"
+        ).__root__
+        assert len(results) > 0
 
         assert stat.name() == "empirical_cdf"
 

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -35,7 +35,7 @@ class TestStatistics:
             {"branch": ["treatment"] * 10 + ["control"] * 10, "value": list(range(20))}
         )
         results = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
 
         branch_results = [r for r in results if r.comparison is None]
@@ -53,7 +53,7 @@ class TestStatistics:
             }
         )
         results = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         branch_results = [r for r in results if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
@@ -71,7 +71,7 @@ class TestStatistics:
             {"branch": ["treatment"] * 20 + ["control"] * 10, "value": list(range(30))}
         )
         results = stat.transform(
-            test_data, "identity", "control", None, AnalysisBasis.enrollments, "all"
+            test_data, "identity", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         assert all(r.metric == "identity" for r in results)
         assert [r.point for r in results if r.branch == "treatment"] == [20]
@@ -88,7 +88,7 @@ class TestStatistics:
             }
         )
         results = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         assert all(r.metric == "value" for r in results)
         assert [r.point for r in results if r.branch == "treatment"] == [5]
@@ -105,7 +105,7 @@ class TestStatistics:
             }
         )
         results = stat.transform(
-            test_data, "value", "control", None, AnalysisBasis.enrollments, "all"
+            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         assert all(r.metric == "value" for r in results)
         assert [r.point for r in results if r.branch == "treatment"] == [15]
@@ -125,7 +125,7 @@ class TestStatistics:
             }
         )
         results = stat.apply(
-            test_data, "value", experiments[1], AnalysisBasis.enrollments, "all"
+            test_data, "value", experiments[1], AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
 
         branch_results = [r for r in results if r.comparison is None]
@@ -187,14 +187,14 @@ class TestStatistics:
 
     def test_kde(self, wine):
         stat = KernelDensityEstimate()
-        results = stat.transform(wine, "ash", "*", None, AnalysisBasis.enrollments, "all").__root__
+        results = stat.transform(wine, "ash", "*", None, AnalysisBasis.ENROLLMENTS, "all").__root__
         assert len(results) > 0
 
     def test_kde_with_geom_zero(self, wine):
         wine = wine.copy()
         wine.loc[0, "ash"] = 0
         stat = KernelDensityEstimate(log_space=True)
-        results = stat.transform(wine, "ash", "*", None, AnalysisBasis.enrollments, "all").__root__
+        results = stat.transform(wine, "ash", "*", None, AnalysisBasis.ENROLLMENTS, "all").__root__
         for r in results:
             assert isinstance(r.point, float)
         df = pd.DataFrame([r.dict() for r in results])
@@ -203,19 +203,19 @@ class TestStatistics:
     def test_ecdf(self, wine, experiments):
         stat = EmpiricalCDF()
         results = stat.transform(
-            wine, "ash", "*", experiments[0], AnalysisBasis.enrollments, "all"
+            wine, "ash", "*", experiments[0], AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         assert len(results) > 0
 
         logstat = EmpiricalCDF(log_space=True)
         results = logstat.transform(
-            wine, "ash", "*", experiments[0], AnalysisBasis.enrollments, "all"
+            wine, "ash", "*", experiments[0], AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         assert len(results) > 0
 
         wine["ash"] = -wine["ash"]
         results = logstat.transform(
-            wine, "ash", "*", experiments[0], AnalysisBasis.enrollments, "all"
+            wine, "ash", "*", experiments[0], AnalysisBasis.ENROLLMENTS, "all"
         ).__root__
         assert len(results) > 0
 
@@ -251,11 +251,11 @@ class TestStatistics:
                 "ad_ratio": np.nan,
             }
         )
-        result = stat.transform(
+        results = stat.transform(
             test_data, "ad_ratio", "control", None, AnalysisBasis.ENROLLMENTS, "all"
-        )
+        ).__root__
 
-        branch_results = [r for r in result.data if r.comparison is None]
+        branch_results = [r for r in results if r.comparison is None]
         treatment_result = [r for r in branch_results if r.branch == "treatment"][0]
         control_result = [r for r in branch_results if r.branch == "control"][0]
         assert treatment_result.point == pytest.approx(control_result.point, rel=1e-5)

--- a/requirements.in
+++ b/requirements.in
@@ -156,7 +156,7 @@ mozilla-metric-config-parser==2023.6.4
     # via
     #   mozanalysis
     #   mozilla-jetstream
-mozilla-nimbus-schemas==2023.6.5
+mozilla-nimbus-schemas==2023.6.6
 msgpack==1.0.5
     # via distributed
 mypy==1.4.0

--- a/requirements.in
+++ b/requirements.in
@@ -152,7 +152,7 @@ mccabe==0.7.0
 mozanalysis==2023.5.3
     # via mozilla-jetstream
     # via -r -
-mozilla-metric-config-parser==2023.6.5
+mozilla-metric-config-parser==2023.6.6
     # via
     #   mozanalysis
     #   mozilla-jetstream

--- a/requirements.in
+++ b/requirements.in
@@ -156,6 +156,7 @@ mozilla-metric-config-parser==2023.6.4
     # via
     #   mozanalysis
     #   mozilla-jetstream
+mozilla-nimbus-schemas==2023.6.5
 msgpack==1.0.5
     # via distributed
 mypy==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -778,9 +778,9 @@ mozanalysis==2023.5.3 \
     --hash=sha256:3dfbe91e69a7460a7d8bf75c19ca2501d6e8160c4ad3a41d142f5601f1721b4b \
     --hash=sha256:a9bdb4d3aab005f9765b8828aa0a96a5b04d80df279156f8fd84a6e711a7a879
     # via -r requirements.in
-mozilla-metric-config-parser==2023.6.5 \
-    --hash=sha256:b1d00ae8a03ef6dfd6cbd744ade46350285f88eeee22637ec41c2b1b3194c8d8 \
-    --hash=sha256:f64d5229ba05a191cbd3455cc09ee434b4de57d5ed62feb212fb2c22e8c263bd
+mozilla-metric-config-parser==2023.6.6 \
+    --hash=sha256:99561d3c0814ffd4770d21d4b4b330a0357907108c17edc4db966b736f9cebcd \
+    --hash=sha256:e687dc5ff5a348fec32b5dd9a606a56fe5693cdff385882cd36a84247c41c38b
     # via
     #   -r requirements.in
     #   mozanalysis

--- a/requirements.txt
+++ b/requirements.txt
@@ -784,9 +784,9 @@ mozilla-metric-config-parser==2023.6.4 \
     # via
     #   -r requirements.in
     #   mozanalysis
-mozilla-nimbus-schemas==2023.6.5 \
-    --hash=sha256:a3ad98e94241ed5586d8cd3cd5bb02e50343264042ef1ef11e0cf23b79737ffb \
-    --hash=sha256:ed314284d5aa4ae27aebb44029133b1f76a70389f125638382b87cfcec140736
+mozilla-nimbus-schemas==2023.6.6 \
+    --hash=sha256:7ef12f52352af9e21d6e3d9bfa629247f4c066d5fd501d1e5221813879d7b39f \
+    --hash=sha256:c61772adc7ac351e4771726f34c742f23790f393a137ce160756c61ab377f697
     # via -r requirements.in
 msgpack==1.0.5 \
     --hash=sha256:06f5174b5f8ed0ed919da0e62cbd4ffde676a374aba4020034da05fab67b9164 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -784,6 +784,10 @@ mozilla-metric-config-parser==2023.6.4 \
     # via
     #   -r requirements.in
     #   mozanalysis
+mozilla-nimbus-schemas==2023.6.5 \
+    --hash=sha256:a3ad98e94241ed5586d8cd3cd5bb02e50343264042ef1ef11e0cf23b79737ffb \
+    --hash=sha256:ed314284d5aa4ae27aebb44029133b1f76a70389f125638382b87cfcec140736
+    # via -r requirements.in
 msgpack==1.0.5 \
     --hash=sha256:06f5174b5f8ed0ed919da0e62cbd4ffde676a374aba4020034da05fab67b9164 \
     --hash=sha256:0c05a4a96585525916b109bb85f8cb6511db1c6f5b9d9cbcbc940dc6b4be944b \
@@ -1168,6 +1172,44 @@ pycodestyle==2.10.0 \
     # via
     #   -r requirements.in
     #   flake8
+pydantic==1.10.9 \
+    --hash=sha256:07293ab08e7b4d3c9d7de4949a0ea571f11e4557d19ea24dd3ae0c524c0c334d \
+    --hash=sha256:0a2aabdc73c2a5960e87c3ffebca6ccde88665616d1fd6d3db3178ef427b267a \
+    --hash=sha256:0da48717dc9495d3a8f215e0d012599db6b8092db02acac5e0d58a65248ec5bc \
+    --hash=sha256:128d9453d92e6e81e881dd7e2484e08d8b164da5507f62d06ceecf84bf2e21d3 \
+    --hash=sha256:2196c06484da2b3fded1ab6dbe182bdabeb09f6318b7fdc412609ee2b564c49a \
+    --hash=sha256:2e9aec8627a1a6823fc62fb96480abe3eb10168fd0d859ee3d3b395105ae19a7 \
+    --hash=sha256:3283b574b01e8dbc982080d8287c968489d25329a463b29a90d4157de4f2baaf \
+    --hash=sha256:3c52eb595db83e189419bf337b59154bdcca642ee4b2a09e5d7797e41ace783f \
+    --hash=sha256:4b466a23009ff5cdd7076eb56aca537c745ca491293cc38e72bf1e0e00de5b91 \
+    --hash=sha256:517a681919bf880ce1dac7e5bc0c3af1e58ba118fd774da2ffcd93c5f96eaece \
+    --hash=sha256:5f8bbaf4013b9a50e8100333cc4e3fa2f81214033e05ac5aa44fa24a98670a29 \
+    --hash=sha256:6257bb45ad78abacda13f15bde5886efd6bf549dd71085e64b8dcf9919c38b60 \
+    --hash=sha256:67195274fd27780f15c4c372f4ba9a5c02dad6d50647b917b6a92bf00b3d301a \
+    --hash=sha256:6cafde02f6699ce4ff643417d1a9223716ec25e228ddc3b436fe7e2d25a1f305 \
+    --hash=sha256:73ef93e5e1d3c8e83f1ff2e7fdd026d9e063c7e089394869a6e2985696693766 \
+    --hash=sha256:7845b31959468bc5b78d7b95ec52fe5be32b55d0d09983a877cca6aedc51068f \
+    --hash=sha256:7847ca62e581e6088d9000f3c497267868ca2fa89432714e21a4fb33a04d52e8 \
+    --hash=sha256:7e1d5290044f620f80cf1c969c542a5468f3656de47b41aa78100c5baa2b8276 \
+    --hash=sha256:7ee829b86ce984261d99ff2fd6e88f2230068d96c2a582f29583ed602ef3fc2c \
+    --hash=sha256:83fcff3c7df7adff880622a98022626f4f6dbce6639a88a15a3ce0f96466cb60 \
+    --hash=sha256:939328fd539b8d0edf244327398a667b6b140afd3bf7e347cf9813c736211896 \
+    --hash=sha256:95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be \
+    --hash=sha256:963671eda0b6ba6926d8fc759e3e10335e1dc1b71ff2a43ed2efd6996634dafb \
+    --hash=sha256:970b1bdc6243ef663ba5c7e36ac9ab1f2bfecb8ad297c9824b542d41a750b298 \
+    --hash=sha256:9863b9420d99dfa9c064042304868e8ba08e89081428a1c471858aa2af6f57c4 \
+    --hash=sha256:ad428e92ab68798d9326bb3e5515bc927444a3d71a93b4a2ca02a8a5d795c572 \
+    --hash=sha256:b48d3d634bca23b172f47f2335c617d3fcb4b3ba18481c96b7943a4c634f5c8d \
+    --hash=sha256:b9cd67fb763248cbe38f0593cd8611bfe4b8ad82acb3bdf2b0898c23415a1f82 \
+    --hash=sha256:d111a21bbbfd85c17248130deac02bbd9b5e20b303338e0dbe0faa78330e37e0 \
+    --hash=sha256:e1aa5c2410769ca28aa9a7841b80d9d9a1c5f223928ca8bec7e7c9a34d26b1d4 \
+    --hash=sha256:e692dec4a40bfb40ca530e07805b1208c1de071a18d26af4a2a0d79015b352ca \
+    --hash=sha256:e7c9900b43ac14110efa977be3da28931ffc74c27e96ee89fbcaaf0b0fe338e1 \
+    --hash=sha256:eec39224b2b2e861259d6f3c8b6290d4e0fbdce147adb797484a42278a1a486f \
+    --hash=sha256:f0b7628fb8efe60fe66fd4adadd7ad2304014770cdc1f4934db41fe46cc8825f \
+    --hash=sha256:f50e1764ce9353be67267e7fd0da08349397c7db17a562ad036aa7c8f4adfdb6 \
+    --hash=sha256:fab81a92f42d6d525dd47ced310b0c3e10c416bbfae5d59523e63ea22f82b31e
+    # via mozilla-nimbus-schemas
 pyflakes==3.0.1 \
     --hash=sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf \
     --hash=sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd
@@ -1470,6 +1512,7 @@ typing-extensions==4.6.3 \
     #   -r requirements.in
     #   cattrs
     #   mypy
+    #   pydantic
 tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \
     --hash=sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "jinja2",
         "mozanalysis",
         "mozilla-metric-config-parser",
+        "mozilla-nimbus-schemas",
         "pyarrow",
         "pytz",
         "PyYAML",


### PR DESCRIPTION
The goal of this PR is to use the new `mozilla-nimbus-schemas` package to validate data that Jetstream is exporting to Experimenter.

The broader goal of this effort is to provide a single place where shared schemas are defined in order to improve stability of the data relationship between systems within Nimbus.