### PR TITLE
Speed up updating last_updated timestamps

### DIFF
--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -22,3 +22,31 @@ class TestBigQueryClient:
         )
 
         assert client.experiment_table_first_updated("test-experiment") == earliest_timestamp
+
+    def test_tables_matching_regex(self, client, temporary_dataset):
+        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
+        assert client.tables_matching_regex("^enrollments_.*$") == ["enrollments_test_experiment"]
+        assert client.tables_matching_regex("nothing") == []
+
+    def test_touch_tables(self, client, temporary_dataset):
+        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
+        client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_week_0")
+        client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_day_12")
+        client.client.create_table(f"{temporary_dataset}.test_foo_bar_day")
+
+        client.touch_tables("test-experiment")
+
+        enrollment_table = client.client.get_table(
+            f"{temporary_dataset}.enrollments_test_experiment"
+        )
+        assert enrollment_table.labels
+        assert enrollment_table.labels["last_updated"]
+
+        stats_table = client.client.get_table(
+            f"{temporary_dataset}.statistics_test_experiment_day_12"
+        )
+        assert stats_table.labels
+        assert stats_table.labels["last_updated"]
+
+        unrelated_table = client.client.get_table(f"{temporary_dataset}.test_foo_bar_day")
+        assert unrelated_table.labels == {}


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/1741

`jetstream rerun` no longer takes half an hour to actually get started. `last_updated` labels now get updated within seconds