### PR TITLE
fix #1881: only create enrollments if enrollment is paused

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -472,19 +472,20 @@ class AnalysisExecutor:
                     self._delete_enrollment_table(config)
 
                 # make sure enrollment is actually ended (and enrollment is not manually overridden)
-                if (
-                    hasattr(config.experiment, "is_enrollment_paused")
-                    and config.experiment.is_enrollment_paused is False
-                ) and (
-                    config.experiment.proposed_enrollment
-                    == config.experiment.experiment.proposed_enrollment
-                    and config.experiment.enrollment_end_date
-                    == config.experiment.experiment.enrollment_end_date
-                    and config.experiment.experiment_spec.enrollment_period is None
+                if not (
+                    (
+                        hasattr(config.experiment, "is_enrollment_paused")
+                        and config.experiment.is_enrollment_paused is False
+                    )
+                    and (
+                        config.experiment.proposed_enrollment
+                        == config.experiment.experiment.proposed_enrollment
+                        and config.experiment.enrollment_end_date
+                        == config.experiment.experiment.enrollment_end_date
+                        and config.experiment.experiment_spec.enrollment_period is None
+                    )
                 ):
-                    raise EnrollmentNotCompleteException(config.experiment.normandy_slug)
-
-                analysis.ensure_enrollments(end_date)
+                    analysis.ensure_enrollments(end_date)
             except Exception as e:
                 logger.exception(
                     str(e), exc_info=e, extra={"experiment": config.experiment.normandy_slug}

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -43,11 +43,7 @@ from .artifacts import ArtifactManager
 from .bigquery_client import BigQueryClient
 from .config import CONFIGS, METRIC_HUB_REPO, ConfigLoader, _ConfigLoader, validate
 from .dryrun import DryRunFailedError
-from .errors import (
-    EnrollmentNotCompleteException,
-    ExplicitSkipException,
-    ValidationException,
-)
+from .errors import ExplicitSkipException, ValidationException
 from .experimenter import ExperimentCollection
 from .export_json import export_experiment_logs, export_statistics_tables
 from .logging import LogConfiguration

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -17,7 +17,6 @@ from pytz import UTC
 from jetstream import cli, experimenter
 from jetstream.artifacts import ArtifactManager
 from jetstream.config import ConfigLoader, _ConfigLoader
-from jetstream.errors import EnrollmentNotCompleteException
 
 
 @pytest.fixture(name="cli_experiments")
@@ -506,11 +505,12 @@ class TestAnalysisExecutor:
         Analysis = Mock()
         monkeypatch.setattr("jetstream.cli.Analysis", Analysis)
 
-        with pytest.raises(EnrollmentNotCompleteException):
-            executor.ensure_enrollments(
-                experiment_getter=cli_experiments_enrollment_incomplete,
-                config_getter=ConfigLoader,
-            )
+        executor.ensure_enrollments(
+            experiment_getter=cli_experiments_enrollment_incomplete,
+            config_getter=ConfigLoader,
+        )
+
+        Analysis.ensure_enrollments.assert_not_called()
 
 
 class TestSerialExecutorStrategy:


### PR DESCRIPTION
This should make the error log less cluttered with `EnrollmentNotCompleteException`. Open to debate whether this is a concern or whether we should log something in lieu of raising an exception.