### PR TITLE
add source to logging

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -46,7 +46,7 @@ from .dryrun import DryRunFailedError
 from .errors import ExplicitSkipException, ValidationException
 from .experimenter import ExperimentCollection
 from .export_json import export_experiment_logs, export_statistics_tables
-from .logging import LogConfiguration, LOG_SOURCE
+from .logging import LOG_SOURCE, LogConfiguration
 from .metadata import export_metadata
 from .platform import PLATFORM_CONFIGS
 from .preview import sampled_enrollment_query

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -504,6 +504,9 @@ log_dataset_id_option = click.option(
 log_table_id_option = click.option(
     "--log_table_id", "--log-table-id", default="logs", help="Table to write logs to"
 )
+log_source = click.option(
+    "--log-source", "--log_source", default="SIZING", help="Source column for logs"
+)
 
 
 @click.group()
@@ -523,6 +526,7 @@ log_table_id_option = click.option(
     help="Table to write task monitoring logs to",
 )
 @click.option("--log_to_bigquery", "--log-to-bigquery", is_flag=True, default=False)
+@log_source
 @click.pass_context
 def cli(
     ctx,
@@ -532,6 +536,7 @@ def cli(
     task_profiling_log_table_id,
     task_monitoring_log_table_id,
     log_to_bigquery,
+    log_source,
 ):
     log_config = LogConfiguration(
         log_project_id,
@@ -540,6 +545,7 @@ def cli(
         task_profiling_log_table_id,
         task_monitoring_log_table_id,
         log_to_bigquery,
+        log_source,
     )
     log_config.setup_logger()
     ctx.ensure_object(dict)
@@ -1426,6 +1432,7 @@ def preview(
             task_monitoring_log_table_id=None,
             log_level=logging.INFO,
             capacity=5,
+            log_source="PREVIEW",
         )
         client.delete_table(f"{project_id}.{dataset_id}.logs_{table}")
 

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -46,7 +46,7 @@ from .dryrun import DryRunFailedError
 from .errors import ExplicitSkipException, ValidationException
 from .experimenter import ExperimentCollection
 from .export_json import export_experiment_logs, export_statistics_tables
-from .logging import LogConfiguration
+from .logging import LogConfiguration, LOG_SOURCE
 from .metadata import export_metadata
 from .platform import PLATFORM_CONFIGS
 from .preview import sampled_enrollment_query
@@ -505,7 +505,11 @@ log_table_id_option = click.option(
     "--log_table_id", "--log-table-id", default="logs", help="Table to write logs to"
 )
 log_source = click.option(
-    "--log-source", "--log_source", default="SIZING", help="Source column for logs"
+    "--log-source",
+    "--log_source",
+    default=LOG_SOURCE.JETSTREAM,
+    type=LOG_SOURCE,
+    help="Source column for logs",
 )
 
 
@@ -1432,7 +1436,7 @@ def preview(
             task_monitoring_log_table_id=None,
             log_level=logging.INFO,
             capacity=5,
-            log_source="PREVIEW",
+            log_source=LOG_SOURCE.PREVIEW,
         )
         client.delete_table(f"{project_id}.{dataset_id}.logs_{table}")
 

--- a/jetstream/logging/__init__.py
+++ b/jetstream/logging/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum
 from typing import Optional
 
 import attr
@@ -6,6 +7,12 @@ import dask.distributed
 from distributed.diagnostics.plugin import WorkerPlugin
 
 from .bigquery_log_handler import BigQueryLogHandler
+
+
+class LOG_SOURCE(str, Enum):
+    JETSTREAM = "jetstream"
+    SIZING = "sizing"
+    PREVIEW = "jetstream-preview"
 
 
 @attr.s(auto_attribs=True)
@@ -20,7 +27,7 @@ class LogConfiguration:
     log_to_bigquery: bool = False
     capacity: int = 50
     log_level: int = logging.WARNING
-    log_source: str = "JETSTREAM"
+    log_source: str = LOG_SOURCE.JETSTREAM
 
     def setup_logger(self, client=None):
         logging.basicConfig(

--- a/jetstream/logging/__init__.py
+++ b/jetstream/logging/__init__.py
@@ -20,6 +20,7 @@ class LogConfiguration:
     log_to_bigquery: bool = False
     capacity: int = 50
     log_level: int = logging.WARNING
+    log_source: str = "JETSTREAM"
 
     def setup_logger(self, client=None):
         logging.basicConfig(
@@ -30,7 +31,12 @@ class LogConfiguration:
 
         if self.log_to_bigquery:
             bigquery_handler = BigQueryLogHandler(
-                self.log_project_id, self.log_dataset_id, self.log_table_id, client, self.capacity
+                self.log_project_id,
+                self.log_dataset_id,
+                self.log_table_id,
+                self.log_source,
+                client,
+                self.capacity,
             )
             bigquery_handler.setLevel(self.log_level)
             logger.addHandler(bigquery_handler)

--- a/jetstream/logging/bigquery_log_handler.py
+++ b/jetstream/logging/bigquery_log_handler.py
@@ -13,6 +13,7 @@ class BigQueryLogHandler(BufferingHandler):
         project_id: str,
         dataset_id: str,
         table_id: str,
+        source: str,
         client: Optional[bigquery.Client] = None,
         capacity=50,
     ):
@@ -22,6 +23,7 @@ class BigQueryLogHandler(BufferingHandler):
         self.client = client
         if client is None:
             self.client = bigquery.Client(project_id)
+        self.source = source
 
         super().__init__(capacity)
 
@@ -32,6 +34,7 @@ class BigQueryLogHandler(BufferingHandler):
                 "timestamp": datetime.datetime.fromtimestamp(record.created).strftime(
                     "%Y-%m-%d %H:%M:%S"
                 ),
+                "source": self.source if not hasattr(record, "source") else record.source,
                 "experiment": None if not hasattr(record, "experiment") else record.experiment,
                 "metric": None if not hasattr(record, "metric") else record.metric,
                 "statistic": None if not hasattr(record, "statistic") else record.statistic,

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -734,6 +734,7 @@ class TestAnalysisIntegration:
         assert error_logs[0].get("statistic") == "bootstrap_mean"
         assert error_logs[0].get("analysis_basis") == "enrollments"
         assert error_logs[0].get("segment") == "all"
+        assert error_logs[0].get("source") == "jetstream"
 
         assert error_logs[1].get("log_level") == "ERROR"
         assert error_logs[1].get("experiment") == "test-experiment"

--- a/jetstream/tests/integration/test_logging_integration.py
+++ b/jetstream/tests/integration/test_logging_integration.py
@@ -22,6 +22,7 @@ class TestLoggingIntegration:
             bigquery.SchemaField("filename", "STRING"),
             bigquery.SchemaField("func_name", "STRING"),
             bigquery.SchemaField("exception_type", "STRING"),
+            bigquery.SchemaField("source", "STRING"),
         ]
 
         table = bigquery.Table(f"{project_id}.{temporary_dataset}.logs", schema=schema)
@@ -84,6 +85,7 @@ class TestLoggingIntegration:
                 and r.log_level == "ERROR"
                 and r.segment == "all"
                 and r.analysis_basis == "enrollments"
+                and r.source == "jetstream"
                 for r in result
             ]
         )

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         pensieve=jetstream.cli:cli
         jetstream=jetstream.cli:cli
     """,
-    # This project does not issue releases, so this number is not meaningful
-    # and should not need to change.
-    version="2023.6.2",
+    # This project does not issue regular releases, only when there
+    # are changes that would be meaningful to our (few) dependents.
+    version="2023.8.1",
 )


### PR DESCRIPTION
[auto-sizing](https://github.com/mozilla/auto-sizing) logs to the same table as jetstream, so this adds a value to help differentiate.

Separately, I have already added a column to the bigquery table, and will submit a similar PR to `auto-sizing`.