### PR TITLE
fix #2008: replace is_enrollment_paused check with enrollment_end_date

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -611,10 +611,7 @@ class Analysis:
         assert self.config.experiment.start_date is not None  # for mypy
 
         # make sure enrollment is actually ended (and enrollment is not manually overridden)
-        if (
-            hasattr(self.config.experiment, "is_enrollment_paused")
-            and self.config.experiment.is_enrollment_paused is False
-        ) and (
+        if (self.config.experiment.enrollment_end_date is not None) and (
             self.config.experiment.proposed_enrollment
             == self.config.experiment.experiment.proposed_enrollment
             and self.config.experiment.enrollment_end_date

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -470,8 +470,7 @@ class AnalysisExecutor:
                 # make sure enrollment is actually ended (and enrollment is not manually overridden)
                 if not (
                     (
-                        hasattr(config.experiment, "is_enrollment_paused")
-                        and config.experiment.is_enrollment_paused is False
+                        config.experiment.enrollment_end_date is not None
                     )
                     and (
                         config.experiment.proposed_enrollment


### PR DESCRIPTION
Per the linked issue:
>As of https://github.com/mozilla/experimenter/pull/9656, the enrollmentEndDate in the v6 API should be either the correct date or null, so we can simply check for that and remove the is_enrollment_paused check, as it will be incorrect for Cirrus experiments.