### PR TITLE
bump mcp version to latest 2023.11.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -161,7 +161,7 @@ mccabe==0.7.0
 mozanalysis==2023.11.2
     # via mozilla-jetstream
     # via -r -
-mozilla-metric-config-parser==2023.10.2
+mozilla-metric-config-parser==2023.11.1
     # via
     #   mozanalysis
     #   mozilla-jetstream

--- a/requirements.txt
+++ b/requirements.txt
@@ -851,9 +851,9 @@ mozanalysis==2023.11.2 \
     --hash=sha256:8978a6240aed6ad0e8c679de911eedea704391865896383f930abfc38de57130 \
     --hash=sha256:cee845bb77bfed65ceadfcb50f957855258c8e1bdd8f762c6df0d97464a12127
     # via -r requirements.in
-mozilla-metric-config-parser==2023.10.2 \
-    --hash=sha256:17ccf8b93e7c531acebb627467f3c481e55d2f68024bc83ae36d058ae1108520 \
-    --hash=sha256:d862aac45c9cd1336d84fe77408b126cf143fbb101ccc577038d262ab9a75342
+mozilla-metric-config-parser==2023.11.1 \
+    --hash=sha256:6a77b1ad0b1024bfa0a21febccc344b6aae17a0314726a5c07a190ee21100e29 \
+    --hash=sha256:e926b30862eb626494a15f94e6c1aaa3e770f09c30bc91979b51f6b3ddca99c5
     # via
     #   -r requirements.in
     #   mozanalysis


### PR DESCRIPTION
there was a bug in metric-config-parser for experiments with outcomes that was fixed in the latest version