### PR TITLE
bump mozanalysis version, add additional fallback case

### DIFF
--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -471,7 +471,16 @@ class LinearModelMean(Statistic):
                 covariate_col_label = f"{self.covariate_adjustment.get('metric', metric)}_pre"
 
         if covariate_col_label and covariate_col_label not in df.columns:
-            logger.warning(f"Falling back to unadjusted inferences for {metric}")
+            logger.warning(
+                f"Falling back to unadjusted inferences for {metric}",
+                extra={
+                    "experiment": experiment.normandy_slug,
+                    "metric": metric,
+                    "statistic": self.name(),
+                    "analysis_basis": analysis_basis.value,
+                    "segment": segment,
+                },
+            )
             covariate_col_label = None
 
         ma_result = mozanalysis.frequentist_stats.linear_models.compare_branches_lm(

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -461,8 +461,18 @@ class LinearModelMean(Statistic):
         covariate_col_label = None
         if self.covariate_adjustment is not None:
             covariate_period = parser_metric.AnalysisPeriod(self.covariate_adjustment["period"])
-            if covariate_period != self.period:
+            # we cannot apply covariate adjustment if the adjusting period is the current period
+            # or if the current period is itself a pre-enrollment period (e.g., cannot adjust
+            # preenrollment_week using preenrollment_days28)
+            if (covariate_period != self.period) and self.period not in (
+                parser_metric.AnalysisPeriod.PREENROLLMENT_WEEK,
+                parser_metric.AnalysisPeriod.PREENROLLMENT_DAYS_28,
+            ):
                 covariate_col_label = f"{self.covariate_adjustment.get('metric', metric)}_pre"
+
+        if covariate_col_label and covariate_col_label not in df.columns:
+            logger.warning(f"Falling back to unadjusted inferences for {metric}")
+            covariate_col_label = None
 
         ma_result = mozanalysis.frequentist_stats.linear_models.compare_branches_lm(
             df,

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -37,6 +37,9 @@ def wine():
 
 
 class SAME_DF:
+    # Needed in order for `Mock.assert_called_with` to compare dataframe arguments 
+    # for equality. See https://stackoverflow.com/questions/44640717/python-unit-test-mock-valueerror-the-truth-value-of-a-dataframe-is-ambiguous # noqa: E501
+    # for more information
     def __init__(self, df: pd.DataFrame):
         self.df = df
 

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -37,7 +37,7 @@ def wine():
 
 
 class SAME_DF:
-    # Needed in order for `Mock.assert_called_with` to compare dataframe arguments 
+    # Needed in order for `Mock.assert_called_with` to compare dataframe arguments
     # for equality. See https://stackoverflow.com/questions/44640717/python-unit-test-mock-valueerror-the-truth-value-of-a-dataframe-is-ambiguous # noqa: E501
     # for more information
     def __init__(self, df: pd.DataFrame):
@@ -179,12 +179,14 @@ class TestStatistics:
             covariate_adjustment={"metric": "value", "period": "preenrollment_week"}, period=period
         )
         m1, m2 = MagicMock(return_value=True), MagicMock(return_value=True)
+        experiment = MagicMock(Experiment)
+        experiment.normandy_slug = "slug"
 
         monkeypatch.setattr("mozanalysis.frequentist_stats.linear_models.compare_branches_lm", m1)
         monkeypatch.setattr("jetstream.statistics.flatten_simple_compare_branches_result", m2)
 
         df = pd.DataFrame({"any_column": [0, 1]})
-        stat.transform(df, "", "", None, None, "")
+        stat.transform(df, "", "", experiment, AnalysisBasis.ENROLLMENTS, "")
 
         m1.assert_called_with(
             SAME_DF(df),

--- a/requirements.in
+++ b/requirements.in
@@ -177,7 +177,7 @@ mccabe==0.7.0
     # via flake8
 mizani==0.11.4
     # via plotnine
-mozanalysis==2024.7.3
+mozanalysis==2024.7.4
     # via mozilla-jetstream
     # via -r -
 mozilla-metric-config-parser==2024.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -972,8 +972,8 @@ mizani==0.11.4 \
     # via
     #   -r requirements.in
     #   plotnine
-mozanalysis==2024.7.3 \
-    --hash=sha256:c8617c930d68e3fc7d65307970e869869395b0ea429cada80cf02f2b785405fc
+mozanalysis==2024.7.4 \
+    --hash=sha256:1b39835d4f735431dca855233bc65a1d34a6141d4c5a093490fc948d53c23de3
     # via -r requirements.in
 mozilla-metric-config-parser==2024.6.1 \
     --hash=sha256:69192cf01e50301163187955490587b1a5c81875d9ae9a7846585b415eab96a8 \


### PR DESCRIPTION
Incorporates additional error checks from most recent mozanalysis version. Also catches case where covariate adjustment was configured correctly, but metric was also configured for the other preenrollment analysis basis. In that case, we do not want to attempt to adjust inferences for `PREENROLLMENT_DAYS_28` using `PREENROLLMENT_WEEK`. Additionally, adds check for missing covariate column, logs a warning and falls back to unadjusted inferences in that case. 

Added 2 unit tests for the new fallback cases. 