### PR TITLE
add mypy back to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
         name: ruff format
         command: venv/bin/ruff format --check jetstream
     - run:
+        name: Mypy
+        command: venv/bin/mypy --check jetstream
+    - run:
         name: PyTest
         command: venv/bin/pytest --ruff --ruff-format --ignore=jetstream/tests/integration/
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
         command: venv/bin/ruff format --check jetstream
     - run:
         name: Mypy
-        command: venv/bin/mypy --check jetstream
+        command: venv/bin/mypy jetstream
     - run:
         name: PyTest
         command: venv/bin/pytest --ruff --ruff-format --ignore=jetstream/tests/integration/


### PR DESCRIPTION
Greedily removed mypy when adding ruff, just adding it back here (it wasn't removed from the tox config).