### PR TITLE
fix: replace dead dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ testing = [
     "ruff",
     "tox",
     "types-futures",
-    "types-pkg-resources",
     "types-protobuf",
     "types-pytz",
     "types-PyYAML",
     "types-requests",
+    "types-setuptools",
     "types-six",
     "types-toml",
 ]


### PR DESCRIPTION
`types-pkg-resources` was yanked from PyPI in favor of `types-setuptools`, which prevented the `update_deps` script from completing successfully (pip-compile was throwing an error).