### PR TITLE
Change jetstream to use v8 api

### DIFF
--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -180,11 +180,11 @@ class ExperimentCollection:
     EXPERIMENTER_API_URL_V1 = "https://experimenter.services.mozilla.com/api/v1/experiments/"
 
     # for nimbus experiments
-    EXPERIMENTER_API_URL_V6 = "https://experimenter.services.mozilla.com/api/v6/experiments/"
+    EXPERIMENTER_API_URL_V8 = "https://experimenter.services.mozilla.com/api/v8/experiments/"
 
     # experiments that are in draft state
-    EXPERIMENTER_API_URL_V6_DRAFTS = (
-        "https://experimenter.services.mozilla.com/api/v6/draft-experiments/"
+    EXPERIMENTER_API_URL_V8_DRAFTS = (
+        "https://experimenter.services.mozilla.com/api/v8/draft-experiments/"
     )
 
     # user agent sent to the Experimenter API
@@ -212,7 +212,7 @@ class ExperimentCollection:
                     )
 
         nimbus_experiments_json = retry_get(
-            session, cls.EXPERIMENTER_API_URL_V6, cls.MAX_RETRIES, cls.USER_AGENT
+            session, cls.EXPERIMENTER_API_URL_V8, cls.MAX_RETRIES, cls.USER_AGENT
         )
         nimbus_experiments = []
 
@@ -228,7 +228,7 @@ class ExperimentCollection:
         if with_draft_experiments:
             # draft experiments are mainly used to compute previews
             draft_experiments_json = retry_get(
-                session, cls.EXPERIMENTER_API_URL_V6_DRAFTS, cls.MAX_RETRIES, cls.USER_AGENT
+                session, cls.EXPERIMENTER_API_URL_V8_DRAFTS, cls.MAX_RETRIES, cls.USER_AGENT
             )
 
             for draft_experiment in draft_experiments_json:

--- a/jetstream/tests/integration/test_experimenter_api.py
+++ b/jetstream/tests/integration/test_experimenter_api.py
@@ -1,0 +1,61 @@
+import datetime as dt
+
+import pytest
+import pytz
+from metric_config_parser.experiment import Branch, Experiment
+
+from jetstream.experimenter import ExperimentCollection
+
+
+@pytest.fixture
+def experiment_collection():
+    try:
+        collection = ExperimentCollection.from_experimenter()
+        return collection
+    except Exception as e:
+        pytest.fail(f"Failed to fetch experiment collection: {e!s}")
+
+
+def test_from_experimenter(experiment_collection):
+    for experiment in experiment_collection.experiments:
+        assert isinstance(experiment, Experiment)
+        for branch in experiment.branches:
+            assert isinstance(branch, Branch)
+
+
+def test_of_type(experiment_collection):
+    v6_experiments = experiment_collection.of_type("v6")
+    for experiment in v6_experiments.experiments:
+        assert experiment.type == "v6"
+
+    v1_experiments = experiment_collection.of_type("v1")
+    for experiment in v1_experiments.experiments:
+        assert experiment.type == "v1"
+
+
+def test_with_slug(experiment_collection):
+    if experiment_collection and experiment_collection.experiments[0].experimenter_slug:
+        example_slug = experiment_collection.experiments[0].experimenter_slug
+        experiments_with_slug = experiment_collection.with_slug(example_slug)
+        for experiment in experiments_with_slug.experiments:
+            assert experiment.experimenter_slug == example_slug
+    else:
+        assert experiment_collection.experiments[0].experimenter_slug is None
+
+
+def test_started_since(experiment_collection):
+    since_date = dt.datetime(2020, 1, 1, tzinfo=pytz.utc)
+    started_experiments = experiment_collection.started_since(since_date)
+    for experiment in started_experiments.experiments:
+        assert experiment.start_date >= since_date
+
+
+def test_ended_after_or_live(experiment_collection):
+    after_date = dt.datetime(2020, 1, 1, tzinfo=pytz.utc)
+    ended_or_live_experiments = experiment_collection.ended_after_or_live(after_date)
+    for experiment in ended_or_live_experiments.experiments:
+        assert (
+            experiment.end_date is None
+            or experiment.end_date >= after_date
+            or experiment.status == "Live"
+        )

--- a/jetstream/tests/integration/test_experimenter_api.py
+++ b/jetstream/tests/integration/test_experimenter_api.py
@@ -1,8 +1,5 @@
-import datetime as dt
-
 import pytest
-import pytz
-from metric_config_parser.experiment import Branch, Experiment
+from metric_config_parser.experiment import Experiment
 
 from jetstream.experimenter import ExperimentCollection
 
@@ -19,43 +16,3 @@ def experiment_collection():
 def test_from_experimenter(experiment_collection):
     for experiment in experiment_collection.experiments:
         assert isinstance(experiment, Experiment)
-        for branch in experiment.branches:
-            assert isinstance(branch, Branch)
-
-
-def test_of_type(experiment_collection):
-    v6_experiments = experiment_collection.of_type("v6")
-    for experiment in v6_experiments.experiments:
-        assert experiment.type == "v6"
-
-    v1_experiments = experiment_collection.of_type("v1")
-    for experiment in v1_experiments.experiments:
-        assert experiment.type == "v1"
-
-
-def test_with_slug(experiment_collection):
-    if experiment_collection and experiment_collection.experiments[0].experimenter_slug:
-        example_slug = experiment_collection.experiments[0].experimenter_slug
-        experiments_with_slug = experiment_collection.with_slug(example_slug)
-        for experiment in experiments_with_slug.experiments:
-            assert experiment.experimenter_slug == example_slug
-    else:
-        assert experiment_collection.experiments[0].experimenter_slug is None
-
-
-def test_started_since(experiment_collection):
-    since_date = dt.datetime(2020, 1, 1, tzinfo=pytz.utc)
-    started_experiments = experiment_collection.started_since(since_date)
-    for experiment in started_experiments.experiments:
-        assert experiment.start_date >= since_date
-
-
-def test_ended_after_or_live(experiment_collection):
-    after_date = dt.datetime(2020, 1, 1, tzinfo=pytz.utc)
-    ended_or_live_experiments = experiment_collection.ended_after_or_live(after_date)
-    for experiment in ended_or_live_experiments.experiments:
-        assert (
-            experiment.end_date is None
-            or experiment.end_date >= after_date
-            or experiment.status == "Live"
-        )

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -649,3 +649,13 @@ def test_ended_after_or_live(experiment_collection):
     assert isinstance(recent, ExperimentCollection)
     assert len(recent.experiments) > 0
     assert all((e.status == "Live" or e.end_date >= date) for e in recent.experiments)
+
+
+def test_of_type(experiment_collection):
+    v6_experiments = experiment_collection.of_type("v6")
+    for experiment in v6_experiments.experiments:
+        assert experiment.type == "v6"
+
+    v1_experiments = experiment_collection.of_type("v1")
+    for experiment in v1_experiments.experiments:
+        assert experiment.type == "v1"

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -451,7 +451,7 @@ def mock_session():
         mocked_value = MagicMock()
         if url == ExperimentCollection.EXPERIMENTER_API_URL_V1:
             mocked_value.json.return_value = json.loads(EXPERIMENTER_FIXTURE_V1)
-        elif url == ExperimentCollection.EXPERIMENTER_API_URL_V6:
+        elif url == ExperimentCollection.EXPERIMENTER_API_URL_V8:
             mocked_value.json.return_value = json.loads(EXPERIMENTER_FIXTURE_V6)
         else:
             raise Exception("Invalid Experimenter API call.")
@@ -471,7 +471,7 @@ def experiment_collection(mock_session):
 def test_from_experimenter(mock_session):
     collection = ExperimentCollection.from_experimenter(mock_session)
     mock_session.get.assert_any_call(ExperimentCollection.EXPERIMENTER_API_URL_V1)
-    mock_session.get.assert_any_call(ExperimentCollection.EXPERIMENTER_API_URL_V6)
+    mock_session.get.assert_any_call(ExperimentCollection.EXPERIMENTER_API_URL_V8)
     assert len(collection.experiments) == 6
     assert isinstance(collection.experiments[0], Experiment)
     assert isinstance(collection.experiments[0].branches[0], Branch)


### PR DESCRIPTION
Currently jetstream uses the v6 api and this changes it to use the v8 api instead. It also adds some tests for the api.