### PR TITLE
feat: add experiment_slug label to experiment tables

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -305,7 +305,9 @@ class Analysis:
                 exposure_signal,
             )
 
-            results = self.bigquery.execute(metrics_sql, res_table_name)
+            results = self.bigquery.execute(
+                metrics_sql, res_table_name, experiment_slug=self.config.experiment.normandy_slug
+            )
             logger.info(
                 f"Metric query cost: {results.slot_millis * COST_PER_SLOT_MS}",
             )
@@ -725,6 +727,7 @@ class Analysis:
                 segment_results,
                 f"statistics_{metrics_table}",
                 job_config=job_config,
+                experiment_slug=self.config.experiment.normandy_slug,
             )
         except google.api_core.exceptions.BadRequest as e:
             # There was a mismatch between the segment_results root dict
@@ -964,6 +967,7 @@ class Analysis:
                 enrollments_sql,
                 enrollments_table,
                 google.cloud.bigquery.job.WriteDisposition.WRITE_EMPTY,
+                experiment_slug=self.config.experiment.normandy_slug,
             )
             logger.info(
                 "Enrollment query cost: " + f"{results.slot_millis * COST_PER_SLOT_MS}",

--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -33,6 +33,24 @@ class TestBigQueryClient:
         assert client.tables_matching_regex("^enrollments_.*$") == ["enrollments_test_experiment"]
         assert client.tables_matching_regex("nothing") == []
 
+    def test_tables_matching_label(self, client, temporary_dataset):
+        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
+        client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_week_2")
+        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment_other")
+        client.add_labels_to_table(
+            "enrollments_test_experiment",
+            {"experiment_slug": "test-experiment"},
+        )
+        client.add_labels_to_table(
+            "statistics_test_experiment_week_2",
+            {"experiment_slug": "test-experiment"},
+        )
+        matching_tables = client.tables_matching_label("test-experiment")
+        assert "enrollments_test_experiment" in matching_tables
+        assert "statistics_test_experiment_week_2" in matching_tables
+        assert "enrollments_test_experiment_other" not in matching_tables
+        assert client.tables_matching_label("nothing") == []
+
     def test_table_exists(self, client, temporary_dataset):
         assert client.table_exists("dummy_table") is False
         client.client.create_table(f"{temporary_dataset}.dummy_table")


### PR DESCRIPTION
Goal here is to add the label to experiment tables whenever they're created, but don't count on it for anything (yet).


```
"experiment_slug": "slug-for-experiment"
```