### PR TITLE
Revert "feat: add experiment_slug label to experiment tables"

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -305,9 +305,7 @@ class Analysis:
                 exposure_signal,
             )
 
-            results = self.bigquery.execute(
-                metrics_sql, res_table_name, experiment_slug=self.config.experiment.normandy_slug
-            )
+            results = self.bigquery.execute(metrics_sql, res_table_name)
             logger.info(
                 f"Metric query cost: {results.slot_millis * COST_PER_SLOT_MS}",
             )
@@ -727,7 +725,6 @@ class Analysis:
                 segment_results,
                 f"statistics_{metrics_table}",
                 job_config=job_config,
-                experiment_slug=self.config.experiment.normandy_slug,
             )
         except google.api_core.exceptions.BadRequest as e:
             # There was a mismatch between the segment_results root dict
@@ -967,7 +964,6 @@ class Analysis:
                 enrollments_sql,
                 enrollments_table,
                 google.cloud.bigquery.job.WriteDisposition.WRITE_EMPTY,
-                experiment_slug=self.config.experiment.normandy_slug,
             )
             logger.info(
                 "Enrollment query cost: " + f"{results.slot_millis * COST_PER_SLOT_MS}",

--- a/jetstream/bigquery_client.py
+++ b/jetstream/bigquery_client.py
@@ -71,28 +71,23 @@ class BigQueryClient:
         return True
 
     def load_table_from_json(
-        self,
-        results: Iterable[dict],
-        table: str,
-        job_config: google.cloud.bigquery.LoadJobConfig,
-        experiment_slug: str | None = None,
+        self, results: Iterable[dict], table: str, job_config: google.cloud.bigquery.LoadJobConfig
     ):
         # wait for the job to complete
         destination_table = f"{self.project}.{self.dataset}.{table}"
         self.client.load_table_from_json(results, destination_table, job_config=job_config).result()
 
         # add a label with the current timestamp to the table
-        labels = {"last_updated": self._current_timestamp_label()}
-        if experiment_slug:
-            labels["experiment_slug"] = experiment_slug
-        self.add_labels_to_table(table, labels)
+        self.add_labels_to_table(
+            table,
+            {"last_updated": self._current_timestamp_label()},
+        )
 
     def execute(
         self,
         query: str,
         destination_table: str | None = None,
         write_disposition: google.cloud.bigquery.job.WriteDisposition | None = None,
-        experiment_slug: str | None = None,
     ) -> google.cloud.bigquery.job.QueryJob:
         dataset = google.cloud.bigquery.dataset.DatasetReference.from_string(
             self.dataset,
@@ -113,39 +108,12 @@ class BigQueryClient:
 
         if destination_table:
             # add a label with the current timestamp to the table
-            labels = {"last_updated": self._current_timestamp_label()}
-            if experiment_slug:
-                labels["experiment_slug"] = experiment_slug
-            self.add_labels_to_table(destination_table, labels)
+            self.add_labels_to_table(
+                destination_table,
+                {"last_updated": self._current_timestamp_label()},
+            )
 
         return job
-
-    def tables_matching_label(self, label_value: str, label_key: str = "experiment_slug"):
-        """Returns a list of tables matching the specified label.
-
-        We query TABLE_OPTIONS instead of using the Python SDK because the SDK
-        does not appear to have a method for getting all tables with a given
-        label, instead requiring that we get each table and check its labels
-        individually (something like `client.get_table(table).labels.get` for
-        each table in the dataset). This would be much less efficient than the
-        convoluted query below.
-        """
-        job = self.client.query(
-            rf"""
-            SELECT
-                table_name
-            FROM
-                {self.dataset}.INFORMATION_SCHEMA.TABLE_OPTIONS
-            WHERE
-                option_name = 'labels'
-                AND COALESCE(REGEXP_EXTRACT(
-                    option_value,
-                    '.*STRUCT\\(\"{label_key}\", \"([^\"]+)\"\\).*'
-                ), '') = '{label_value}'
-            """
-        )
-        result = list(job.result())
-        return [row.table_name for row in result]
 
     def tables_matching_regex(self, regex: str):
         """Returns a list of tables with names matching the specified pattern."""

--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -33,24 +33,6 @@ class TestBigQueryClient:
         assert client.tables_matching_regex("^enrollments_.*$") == ["enrollments_test_experiment"]
         assert client.tables_matching_regex("nothing") == []
 
-    def test_tables_matching_label(self, client, temporary_dataset):
-        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
-        client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_week_2")
-        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment_other")
-        client.add_labels_to_table(
-            "enrollments_test_experiment",
-            {"experiment_slug": "test-experiment"},
-        )
-        client.add_labels_to_table(
-            "statistics_test_experiment_week_2",
-            {"experiment_slug": "test-experiment"},
-        )
-        matching_tables = client.tables_matching_label("test-experiment")
-        assert "enrollments_test_experiment" in matching_tables
-        assert "statistics_test_experiment_week_2" in matching_tables
-        assert "enrollments_test_experiment_other" not in matching_tables
-        assert client.tables_matching_label("nothing") == []
-
     def test_table_exists(self, client, temporary_dataset):
         assert client.table_exists("dummy_table") is False
         client.client.create_table(f"{temporary_dataset}.dummy_table")


### PR DESCRIPTION
Reverts mozilla/jetstream#2226

Label values in bigquery are limited to 63 characters, so slugs longer than that cause an error. Seems like we'll have to find an alternate approach (likely update the regex)