### PR TITLE
feat: store experiment slug in description

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -743,7 +743,7 @@ class Analysis:
             ve = ValueError(error_msg)
             raise ve from e
 
-        self.bigquery.add_labels_to_table(
+        self.bigquery.add_metadata_to_table(
             f"statistics_{metrics_table}", {"schema_version": StatisticResult.SCHEMA_VERSION}
         )
 

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -305,7 +305,9 @@ class Analysis:
                 exposure_signal,
             )
 
-            results = self.bigquery.execute(metrics_sql, res_table_name)
+            results = self.bigquery.execute(
+                metrics_sql, res_table_name, experiment_slug=self.config.experiment.normandy_slug
+            )
             logger.info(
                 f"Metric query cost: {results.slot_millis * COST_PER_SLOT_MS}",
             )
@@ -725,6 +727,7 @@ class Analysis:
                 segment_results,
                 f"statistics_{metrics_table}",
                 job_config=job_config,
+                experiment_slug=self.config.experiment.normandy_slug,
             )
         except google.api_core.exceptions.BadRequest as e:
             # There was a mismatch between the segment_results root dict
@@ -964,6 +967,7 @@ class Analysis:
                 enrollments_sql,
                 enrollments_table,
                 google.cloud.bigquery.job.WriteDisposition.WRITE_EMPTY,
+                experiment_slug=self.config.experiment.normandy_slug,
             )
             logger.info(
                 "Enrollment query cost: " + f"{results.slot_millis * COST_PER_SLOT_MS}",

--- a/jetstream/bigquery_client.py
+++ b/jetstream/bigquery_client.py
@@ -53,8 +53,7 @@ class BigQueryClient:
         self, table_name: str, labels: Mapping[str, str], description: str | None = None
     ) -> None:
         """Adds the provided labels/description to the table."""
-        table_ref = self.client.dataset(self.dataset).table(table_name)
-        table = self.client.get_table(table_ref)
+        table = self.client.get_table(f"{self.project}.{self.dataset}.{table_name}")
         table.labels = labels
         updated_fields = ["labels"]
         if description:
@@ -68,9 +67,8 @@ class BigQueryClient:
         return str(int(time.time()))
 
     def table_exists(self, table_name: str) -> bool:
-        table_ref = self.client.dataset(self.dataset).table(table_name)
         try:
-            self.client.get_table(table_ref)
+            self.client.get_table(f"{self.project}.{self.dataset}.{table_name}")
         except NotFound:
             return False
 
@@ -144,9 +142,10 @@ class BigQueryClient:
                 {self.dataset}.INFORMATION_SCHEMA.TABLE_OPTIONS
             WHERE
                 option_name = 'description'
-                AND COALESCE(option_value, '') = '{description}'
+                AND COALESCE(option_value, '') = '"{description}"'
             """
         )
+        print(job.query)
         result = list(job.result())
         return [row.table_name for row in result]
 

--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -14,14 +14,14 @@ class TestBigQueryClient:
 
         # table created after config loaded
         client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "enrollments_test_experiment",
             {"last_updated": str(int(earliest_timestamp.timestamp()))},
         )
 
         later_timestamp = datetime(2022, 1, 1, 9, 0, 0, 0, tzinfo=pytz.utc)
         client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_day_1")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "statistics_test_experiment_day_1",
             {"last_updated": str(int(later_timestamp.timestamp()))},
         )
@@ -33,23 +33,30 @@ class TestBigQueryClient:
         assert client.tables_matching_regex("^enrollments_.*$") == ["enrollments_test_experiment"]
         assert client.tables_matching_regex("nothing") == []
 
-    def test_tables_matching_label(self, client, temporary_dataset):
+    def test_tables_matching_description(self, client, temporary_dataset):
         client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
         client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_week_2")
         client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment_other")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "enrollments_test_experiment",
-            {"experiment_slug": "test-experiment"},
+            {"test": ""},
+            description="test-experiment",
         )
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "statistics_test_experiment_week_2",
-            {"experiment_slug": "test-experiment"},
+            {"test": ""},
+            description="test-experiment",
         )
-        matching_tables = client.tables_matching_label("test-experiment")
+        client.add_metadata_to_table(
+            "enrollments_test_experiment_other",
+            {"test": ""},
+            description="test-experiment-other",
+        )
+        matching_tables = client.tables_matching_description("test-experiment")
         assert "enrollments_test_experiment" in matching_tables
         assert "statistics_test_experiment_week_2" in matching_tables
         assert "enrollments_test_experiment_other" not in matching_tables
-        assert client.tables_matching_label("nothing") == []
+        assert client.tables_matching_description("nothing") == []
 
     def test_table_exists(self, client, temporary_dataset):
         assert client.table_exists("dummy_table") is False

--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -56,6 +56,7 @@ class TestBigQueryClient:
         assert "enrollments_test_experiment" in matching_tables
         assert "statistics_test_experiment_week_2" in matching_tables
         assert "enrollments_test_experiment_other" not in matching_tables
+        assert len(matching_tables) == 2
         assert client.tables_matching_description("nothing") == []
 
     def test_table_exists(self, client, temporary_dataset):
@@ -129,7 +130,7 @@ class TestBigQueryClient:
             segment="all",
             analysis_basis=AnalysisBasis.EXPOSURES,
         )
-        test_data = StatisticResultCollection.parse_obj([t0, t1, t2])
+        test_data = StatisticResultCollection.model_validate([t0, t1, t2])
 
         job_config = bigquery.LoadJobConfig()
         job_config.schema = StatisticResult.bq_schema

--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -33,6 +33,24 @@ class TestBigQueryClient:
         assert client.tables_matching_regex("^enrollments_.*$") == ["enrollments_test_experiment"]
         assert client.tables_matching_regex("nothing") == []
 
+    def test_tables_matching_label(self, client, temporary_dataset):
+        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment")
+        client.client.create_table(f"{temporary_dataset}.statistics_test_experiment_week_2")
+        client.client.create_table(f"{temporary_dataset}.enrollments_test_experiment_other")
+        client.add_labels_to_table(
+            "enrollments_test_experiment",
+            {"experiment_slug": "test-experiment"},
+        )
+        client.add_labels_to_table(
+            "statistics_test_experiment_week_2",
+            {"experiment_slug": "test-experiment"},
+        )
+        matching_tables = client.tables_matching_label("test-experiment")
+        assert "enrollments_test_experiment" in matching_tables
+        assert "statistics_test_experiment_week_2" in matching_tables
+        assert "enrollments_test_experiment_other" not in matching_tables
+        assert client.tables_matching_label("nothing") == []
+
     def test_table_exists(self, client, temporary_dataset):
         assert client.table_exists("dummy_table") is False
         client.client.create_table(f"{temporary_dataset}.dummy_table")

--- a/jetstream/tests/integration/test_config_integration.py
+++ b/jetstream/tests/integration/test_config_integration.py
@@ -41,7 +41,7 @@ class TestConfigIntegration:
 
         # table created after config loaded
         client.client.create_table(f"{temporary_dataset}.statistics_new_table_day1")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "statistics_new_table_day1",
             {"last_updated": client._current_timestamp_label()},
         )
@@ -61,12 +61,12 @@ class TestConfigIntegration:
         )
 
         client.client.create_table(f"{temporary_dataset}.old_table_day1")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "old_table_day1",
             {"last_updated": client._current_timestamp_label()},
         )
         client.client.create_table(f"{temporary_dataset}.old_table_day2")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "old_table_day2",
             {"last_updated": client._current_timestamp_label()},
         )
@@ -80,12 +80,12 @@ class TestConfigIntegration:
 
     def test_updated_config_while_analysis_active(self, client, temporary_dataset, project_id):
         client.client.create_table(f"{temporary_dataset}.active_table_day0")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "active_table_day0",
             {"last_updated": client._current_timestamp_label()},
         )
         client.client.create_table(f"{temporary_dataset}.active_table_day1")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "active_table_day1",
             {"last_updated": client._current_timestamp_label()},
         )
@@ -97,12 +97,12 @@ class TestConfigIntegration:
         )
 
         client.client.create_table(f"{temporary_dataset}.active_table_day2")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "active_table_day2",
             {"last_updated": client._current_timestamp_label()},
         )
         client.client.create_table(f"{temporary_dataset}.active_table_weekly")
-        client.add_labels_to_table(
+        client.add_metadata_to_table(
             "active_table_weekly",
             {"last_updated": client._current_timestamp_label()},
         )


### PR DESCRIPTION
Ok, round two. We tried storing the experiment slug in the label, but hit a character limit. As far as I can tell, the character limit for descriptions is 1024 instead of 64, so we should be good here. This takes the previous approach and lightly modifies it to use the description instead of a label.