### PR TITLE
Consume segments in jetstream

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1398,6 +1398,7 @@ def preview(
             app_name=platform,
             app_id=PLATFORM_CONFIGS[platform].app_id,
             outcomes=experiment.outcomes if experiment else [],
+            segments=experiment.segments if experiment else [],
             enrollment_end_date=None,
         )
 

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -30,6 +30,11 @@ class Outcome:
 
 
 @attr.s(auto_attribs=True, kw_only=True, slots=True, frozen=True)
+class Segment:
+    slug: str
+
+
+@attr.s(auto_attribs=True, kw_only=True, slots=True, frozen=True)
 class LegacyExperiment:
     """Experimenter Legacy (Normandy) experiment (v1 API)."""
 
@@ -101,6 +106,7 @@ class NimbusExperiment:
     _appName: str | None = None
     _appId: str | None = None
     outcomes: list[Outcome] | None = None
+    segments: list[Segment] | None = None
     enrollmentEndDate: dt.datetime | None = None
     isEnrollmentPaused: bool | None = None
     isRollout: bool = False
@@ -163,6 +169,7 @@ class NimbusExperiment:
             app_name=self.appName,
             app_id=self.appId,
             outcomes=[o.slug for o in self.outcomes] if self.outcomes else [],
+            segments=[s.slug for s in self.segments] if self.segments else [],
             enrollment_end_date=(
                 pytz.utc.localize(self.enrollmentEndDate) if self.enrollmentEndDate else None
             ),

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -14,6 +14,7 @@ from jetstream.experimenter import (
     LegacyExperiment,
     NimbusExperiment,
     Outcome,
+    Segment,
     Variant,
 )
 
@@ -295,6 +296,9 @@ FENIX_EXPERIMENT_FIXTURE = """
     "slug": "default-browser",
     "priority": "primary"
   }],
+  "segments": [{
+    "slug": "regular_users_v3"
+  }],
   "branches": [
     {
       "slug": "control",
@@ -336,6 +340,7 @@ FIREFOX_IOS_EXPERIMENT_FIXTURE = """
    },
    "probeSets":[],
    "outcomes":[],
+   "segments":[],
    "branches":[
       {
          "slug":"a1",
@@ -379,6 +384,7 @@ KLAR_ANDROID_EXPERIMENT_FIXTURE = """
    },
    "probeSets":[],
    "outcomes":[],
+   "segments":[],
    "branches":[
       {
          "slug":"a1",
@@ -422,6 +428,7 @@ FOCUS_ANDROID_EXPERIMENT_FIXTURE = """
    },
    "probeSets":[],
    "outcomes":[],
+   "segments":[],
    "branches":[
       {
          "slug":"a1",
@@ -564,6 +571,7 @@ def test_convert_nimbus_experiment_to_experiment():
     assert experiment.reference_branch == "control"
     assert experiment.is_high_population is False
     assert experiment.outcomes == []
+    assert experiment.segments == []
     assert experiment.is_enrollment_paused is True
 
 
@@ -617,6 +625,8 @@ def test_app_name():
     assert x.appId == "org.mozilla.fenix"
     assert Outcome(slug="default-browser") in x.outcomes
     assert "default-browser" in x.to_experiment().outcomes
+    assert Segment(slug="regular_users_v3") in x.segments
+    assert "regular_users_v3" in x.to_experiment().segments
 
 
 def test_ios_app_name():
@@ -625,6 +635,8 @@ def test_ios_app_name():
     assert x.appId == "org.mozilla.ios.FirefoxBeta"
     assert x.outcomes == []
     assert x.to_experiment().outcomes == []
+    assert x.segments == []
+    assert x.to_experiment().segments == []
 
 
 def test_klar_android_app_name():
@@ -633,6 +645,8 @@ def test_klar_android_app_name():
     assert x.appId == "org.mozilla.klar"
     assert x.outcomes == []
     assert x.to_experiment().outcomes == []
+    assert x.segments == []
+    assert x.to_experiment().segments == []
 
 
 def test_focus_android_app_name():
@@ -641,6 +655,8 @@ def test_focus_android_app_name():
     assert x.appId == "org.mozilla.focus"
     assert x.outcomes == []
     assert x.to_experiment().outcomes == []
+    assert x.segments == []
+    assert x.to_experiment().segments == []
 
 
 def test_ended_after_or_live(experiment_collection):

--- a/requirements.in
+++ b/requirements.in
@@ -184,7 +184,7 @@ mizani==0.11.4
     # via plotnine
 mozanalysis==2024.9.4
     # via mozilla-jetstream
-mozilla-metric-config-parser==2024.9.7
+mozilla-metric-config-parser==2024.9.8
     # via
     #   mozanalysis
     #   mozilla-jetstream

--- a/requirements.txt
+++ b/requirements.txt
@@ -1001,8 +1001,8 @@ mizani==0.11.4 \
 mozanalysis==2024.9.4 \
     --hash=sha256:2d626f50470b2b32a37e1e5a141ccffa73e9ea1015d926ad4278d24bfcc265f9
     # via -r requirements.in
-mozilla-metric-config-parser==2024.9.7 \
-    --hash=sha256:a2945e5153f4c2e72734e8ca8f1e39f2b906f206ce286f7268f05d892890ed4b
+mozilla-metric-config-parser==2024.9.8 \
+    --hash=sha256:276697c2b5592d255fe2cdeb876f9340b6fa5dd89fc2e31e87b0cc0123cdc44b
     # via
     #   -r requirements.in
     #   mozanalysis


### PR DESCRIPTION
Segments are made available to jetstream through the API and this allows for them to be stored within the NimbusExperiment object.