### PR TITLE
chore: update orb to one with non-removed base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.15.0
+  gcp-gcr: circleci/gcp-gcr@0.16.6
 
 jobs:
   build:


### PR DESCRIPTION
`gcp-gcr@0.15.x` uses a base image (ubuntu 20.04) that was deprecated and then removed starting 1 Oct. This updates to the latest version of the orb to unblock image deployments to GCR.