### PR TITLE
chore: add running status filter to argo ui command

### DIFF
--- a/jetstream/argo.py
+++ b/jetstream/argo.py
@@ -67,6 +67,7 @@ def submit_workflow(
             "To connect to Argo dashboard forward port by running: "
             + f"gcloud container clusters get-credentials jetstream --region={zone} && "
             + "kubectl -n argo exec $(kubectl get pod -n argo -l 'app=argo-server' "
+            + "--field-selector=status.phase=Running "
             + "-o jsonpath='{.items[0].metadata.name}') -- argo auth token \n\n"
             + "Copy the Bearer token.\n"
         )


### PR DESCRIPTION
With the argo-server pod restarting yesterday, there are (or were) a few different pods matching the app, and so `items[0]` was not retrieving the correct one. This led to an error and made it difficult to connect to the Argo UI without modifying the command. This updates the help text shown in Jetstream to include a filter that only shows running pods.

I can't think of any instances where this would be a bad idea, but let me know if you have any concerns. In any case, this only changes the log so I don't think it will hurt anything.