### PR TITLE
feat: allow running only statistics

### DIFF
--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -578,7 +578,7 @@ class TestSerialExecutorStrategy:
             ],
             None,
         )
-        fake_analysis().run.assert_called_once_with(run_date)
+        fake_analysis().run.assert_called_once_with(run_date, statistics_only=False)
 
 
 class TestArgoExecutorStrategy:
@@ -643,6 +643,7 @@ class TestArgoExecutorStrategy:
                     "analysis_periods_preenrollment_week": "preenrollment_week",
                     "analysis_periods_preenrollment_days28": "preenrollment_days28",
                     "image": "jetstream",
+                    "statistics_only": False,
                 },
                 monitor_status=False,
                 cluster_ip=None,
@@ -707,6 +708,7 @@ class TestArgoExecutorStrategy:
                     "analysis_periods_preenrollment_week": "preenrollment_week",
                     "analysis_periods_preenrollment_days28": "preenrollment_days28",
                     "image": "unrelated",
+                    "statistics_only": False,
                 },
                 monitor_status=False,
                 cluster_ip=None,

--- a/jetstream/workflows/run.yaml
+++ b/jetstream/workflows/run.yaml
@@ -99,7 +99,8 @@ spec:
         "--analysis_periods={{workflow.parameters.analysis_periods_days28}}",
         "--analysis_periods={{workflow.parameters.analysis_periods_overall}}",
         "--analysis_periods={{workflow.parameters.analysis_periods_preenrollment_week}}",
-        "--analysis_periods={{workflow.parameters.analysis_periods_preenrollment_days28}}"
+        "--analysis_periods={{workflow.parameters.analysis_periods_preenrollment_days28}}",
+        "--statistics-only={{workflow.parameters.statistics_only}}"
       ]
       resources:
         requests:


### PR DESCRIPTION
This came up recently with an experiment that had not configured their statistics properly, but all the metrics were otherwise correct. I also thought this was a good first step towards more discrete executions along the lines of the discrete metric executions I was planning (https://github.com/mozilla/jetstream/pull/2260).