### PR TITLE
chore: fix pandas deprecation warnings

### DIFF
--- a/jetstream/pre_treatment.py
+++ b/jetstream/pre_treatment.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import attr
 import numpy as np
-import pandas as pd
 from pandas import DataFrame
 
 
@@ -47,8 +46,8 @@ class RemoveIndefinites(PreTreatment):
     """Removes null and infinite values."""
 
     def apply(self, df: DataFrame, col: str) -> DataFrame:
-        with pd.option_context("mode.use_inf_as_na", True):
-            return df.dropna(subset=[col])
+        df[col] = df[col].replace(np.inf, np.nan)
+        return df.dropna(subset=[col])
 
 
 @attr.s(auto_attribs=True)

--- a/jetstream/tests/test_pretreatment.py
+++ b/jetstream/tests/test_pretreatment.py
@@ -7,7 +7,7 @@ from jetstream import pre_treatment
 
 @pytest.fixture
 def example_data():
-    return pd.DataFrame([{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 7}])
+    return pd.DataFrame([{"a": 1.0, "b": 2.0}, {"a": 3.0, "b": 4.0}, {"a": 5.0, "b": 7.0}])
 
 
 class TestPreTreatment:


### PR DESCRIPTION
There were two warnings:
- one complained about setting an incompatible dtype when setting `example_data.iloc[1, 1] = np.inf` in the test. `np.inf` is a float so I just changed the fixture to floats instead of ints.
- second warning was because of a deprecated option `use_inf_as_na` in `RemoveIndefinites`, so now we explicitly change `np.inf` to `np.nan` and then call `dropna`. Apparently this is also faster, but [we don't appear](https://github.com/search?q=org%3Amozilla%20remove_indefinites&type=code) to be using it anywhere anyway, so probably won't matter!