### PR TITLE
fix: fix metrics table check in stats_only

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -870,15 +870,22 @@ class Analysis:
                     )
                     continue
 
-                if statistics_only and not self.bigquery.table_exists(metrics_table):
-                    logger.warning(
-                        f"Cannot compute only statistics for period {period.value}; "
-                        "metrics table does not exist!",
-                        extra={
-                            "experiment": self.config.experiment.normandy_slug,
-                            "analysis_basis": analysis_basis.value,
-                        },
+                if statistics_only:
+                    metrics_table_name = self._table_name(
+                        period.value,
+                        len(time_limits.analysis_windows),
+                        analysis_basis=analysis_basis,
                     )
+                    if not self.bigquery.table_exists(metrics_table_name):
+                        logger.warning(
+                            f"Cannot compute only statistics for period {period.value}; "
+                            "metrics table does not exist!",
+                            extra={
+                                "experiment": self.config.experiment.normandy_slug,
+                                "analysis_basis": analysis_basis.value,
+                            },
+                        )
+                        continue
 
                 segment_labels = ["all"] + [s.name for s in self.config.experiment.segments]
                 for segment in segment_labels:

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -752,7 +752,7 @@ statistics_only_option = click.option(
     "--stats-only",
     "--skip-metrics",
     help="Skip the metrics queries and only calculate statistics (metrics tables must exist!).",
-    type=bool,
+    is_flag=True,
     default=False,
 )
 


### PR DESCRIPTION
I tried using this on a real experiment today, and got an error from `table_exists` saying `Invalid table ID "Delayed('calculate_metrics-....')"`.

Previously, the table name was coming from `calculate_metrics` which is a dask.delayed function, so instead I'll get it directly from `_table_name` for the purposes of this.

Other improvements:
- `--statistics-only` option is now a flag
- skip statistics calculations if metrics table doesn't exist (previously just logged warning)