### PR TITLE
fix: argo workflow needs stats-only arg to not be a flag

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -752,7 +752,7 @@ statistics_only_option = click.option(
     "--stats-only",
     "--skip-metrics",
     help="Skip the metrics queries and only calculate statistics (metrics tables must exist!).",
-    is_flag=True,
+    type=bool,
     default=False,
 )
 


### PR DESCRIPTION
So there seems to be a way to do a ternary operator like
```
"{{workflow.parameters.statistics_only}} ? '--statistics-only' : ''"
```
in the arguments somewhere in the run.yaml, but I couldn't figure it out. Maybe because it's the end of the week, maybe because it doesn't work in the place I need it, not sure.

Either way, we need to have this fixed to unblock Jetstream executation, so this will have to do for now.