### PR TITLE
chore: refactor tox.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,20 @@ pip install -e .
 
   - To run integration tests, run `tox -e py310-integration`.
 
-### Linting
+### Linting / Formatting
 
-`ruff check jetstream`
+We use `ruff` for linting and formatting:
+- **lint**: `ruff check jetstream`
+- **format**: `ruff format --check jetstream`
 
-`ruff` can also fix lint issues:
-- `ruff format jetstream`
+`ruff` can also fix (some) issues:
+- **lint**: `ruff check jetstream --fix`
+- **format**: `ruff format jetstream`
+
+We also use `mypy`:
+- `mypy -p jetstream`
+
+You can also run `tox py310-format` to run all the ruff and mypy checks.
 
 
 ## Dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
-envlist = py310, py310-mypy
+envlist = py310-format, py310
 
 [testenv]
 deps = -rrequirements.txt
 commands =
-  ruff check jetstream
-  ruff format --check jetstream
-  mypy -p jetstream
   pytest \
     {envsitepackagesdir}/jetstream \
     --cov={envsitepackagesdir}/jetstream \
@@ -17,6 +14,12 @@ passenv = GOOGLE_APPLICATION_CREDENTIALS
 
 [testenv:py310-integration]
 commands = pytest --integration {envsitepackagesdir}/jetstream {posargs}
+
+[testenv:py310-format]
+commands =
+  ruff check jetstream
+  ruff format --check jetstream
+  mypy -p jetstream
 
 [testenv:py310-mypy]
 commands = mypy -p jetstream


### PR DESCRIPTION
Realized that after some previous changes, we were running mypy twice with the default `tox`, so I switched things up a bit so it should run just once. 

Also took the opportunity to pull out the lint/format commands into their own tox env so they can be run independently from the tests.