### PR TITLE
chore: remove normandy experiments

### DIFF
--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import json
 import logging
 import re
 from datetime import timedelta
@@ -24,9 +23,7 @@ from jetstream.errors import (
     EnrollmentNotCompleteException,
     ExplicitSkipException,
     HighPopulationException,
-    NoEnrollmentPeriodException,
 )
-from jetstream.experimenter import LegacyExperiment
 from jetstream.metric import Metric
 
 logger = logging.getLogger(__name__)
@@ -80,109 +77,6 @@ def test_get_timelimits_if_ready(experiments):
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(days=34)
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAYS_28, date)
-
-
-def test_regression_20200320():
-    experiment_json = r"""
-        {
-          "experiment_url": "https://experimenter.services.mozilla.com/experiments/impact-of-level-2-etp-on-a-custom-distribution/",
-          "type": "pref",
-          "name": "Impact of Level 2 ETP on a Custom Distribution",
-          "slug": "impact-of-level-2-etp-on-a-custom-distribution",
-          "public_name": "Impact of Level 2 ETP",
-          "status": "Live",
-          "start_date": 1580169600000,
-          "end_date": 1595721600000,
-          "proposed_start_date": 1580169600000,
-          "proposed_enrollment": null,
-          "proposed_duration": 180,
-          "normandy_slug": "pref-impact-of-level-2-etp-on-a-custom-distribution-release-72-80-bug-1607493",
-          "normandy_id": 906,
-          "other_normandy_ids": [],
-          "variants": [
-            {
-              "description": "",
-              "is_control": true,
-              "name": "treatment",
-              "ratio": 100,
-              "slug": "treatment",
-              "value": "true",
-              "addon_release_url": null,
-              "preferences": []
-            }
-          ]
-        }
-    """  # noqa
-    experiment = LegacyExperiment.from_dict(json.loads(experiment_json)).to_experiment()
-    config = AnalysisSpec().resolve(experiment, ConfigLoader.configs)
-    analysis = Analysis("test", "test", config)
-    with pytest.raises(NoEnrollmentPeriodException):
-        analysis.run(current_date=dt.datetime(2020, 3, 19, tzinfo=pytz.utc), dry_run=True)
-
-
-def test_regression_20200316(monkeypatch):
-    experiment_json = r"""
-    {
-      "experiment_url": "https://blah/experiments/search-tips-aka-nudges/",
-      "type": "addon",
-      "name": "Search Tips aka Nudges",
-      "slug": "search-tips-aka-nudges",
-      "public_name": "Search Tips",
-      "public_description": "Search Tips are designed to increase engagement with the QuantumBar.",
-      "status": "Live",
-      "countries": [],
-      "platform": "All Platforms",
-      "start_date": 1578960000000,
-      "end_date": 1584921600000,
-      "population": "2% of Release Firefox 72.0 to 74.0",
-      "population_percent": "2.0000",
-      "firefox_channel": "Release",
-      "firefox_min_version": "72.0",
-      "firefox_max_version": "74.0",
-      "addon_experiment_id": null,
-      "addon_release_url": "https://bugzilla.mozilla.org/attachment.cgi?id=9120542",
-      "pref_branch": null,
-      "pref_name": null,
-      "pref_type": null,
-      "proposed_start_date": 1578960000000,
-      "proposed_enrollment": 21,
-      "proposed_duration": 69,
-      "normandy_slug": "addon-search-tips-aka-nudges-release-72-74-bug-1603564",
-      "normandy_id": 902,
-      "other_normandy_ids": [],
-      "variants": [
-        {
-          "description": "Standard address bar experience",
-          "is_control": false,
-          "name": "control",
-          "ratio": 50,
-          "slug": "control",
-          "value": null,
-          "addon_release_url": null,
-          "preferences": []
-        },
-        {
-          "description": "",
-          "is_control": true,
-          "name": "treatment",
-          "ratio": 50,
-          "slug": "treatment",
-          "value": null,
-          "addon_release_url": null,
-          "preferences": []
-        }
-      ]
-    }
-    """
-    experiment = LegacyExperiment.from_dict(json.loads(experiment_json)).to_experiment()
-    config = AnalysisSpec().resolve(experiment, ConfigLoader.configs)
-
-    monkeypatch.setattr("jetstream.analysis.Analysis.ensure_enrollments", Mock())
-    pre_start_time = dt.datetime.now(tz=pytz.utc)
-    analysis = Analysis("test", "test", config)
-    analysis.run(current_date=dt.datetime(2020, 3, 16, tzinfo=pytz.utc), dry_run=True)
-    assert analysis.start_time is not None
-    assert analysis.start_time >= pre_start_time
 
 
 def test_validate_doesnt_explode(experiments, monkeypatch):

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -11,168 +11,10 @@ from metric_config_parser.experiment import Branch, BucketConfig, Experiment
 
 from jetstream.experimenter import (
     ExperimentCollection,
-    LegacyExperiment,
     NimbusExperiment,
     Outcome,
     Segment,
-    Variant,
 )
-
-LEGACY_EXPERIMENTER_FIXTURE = r"""
-[
-  {
-    "experiment_url": "https://experimenter.services.mozilla.com/experiments/search-topsites/",
-    "type": "addon",
-    "name": "Activity Stream Search TopSites",
-    "slug": "search-topsites",
-    "public_name": "TopSites for Search",
-    "public_description": "We believe we can deliver an enhanced product experience by exposing these Topsites in a new context, allowing users to navigate even more quickly and easily than they can today.",
-    "status": "Complete",
-    "client_matching": "Prefs: Exclude users with the following prefs:\r\n\r\nbrowser.newtabpage.activity-stream.feeds.topsites = false\r\nbrowser.privatebrowsing.autostart = true\r\n\r\nExperiments:\r\n\r\nAny additional filters:",
-    "locales": [],
-    "countries": [],
-    "platform": "All Platforms",
-    "start_date": 1568678400000,
-    "end_date": 1574121600000,
-    "population": "0.9% of Release Firefox 69.0",
-    "population_percent": "0.9000",
-    "firefox_channel": "Release",
-    "firefox_min_version": "69.0",
-    "firefox_max_version": null,
-    "addon_experiment_id": "mythmon says this isn't necessary for new-style experiments like this one",
-    "addon_release_url": "https://bugzilla.mozilla.org/attachment.cgi?id=9091835",
-    "pref_branch": null,
-    "pref_name": null,
-    "pref_type": null,
-    "normandy_slug": "addon-activity-stream-search-topsites-release-69-1576277",
-    "normandy_id": null,
-    "other_normandy_ids": null,
-    "proposed_start_date": 1568592000000,
-    "proposed_enrollment": 14,
-    "proposed_duration": 60,
-    "variants": [
-      {
-        "description": "primary branch displaying Top Sites before the user starts typing",
-        "is_control": false,
-        "name": "treatment",
-        "ratio": 50,
-        "slug": "treatment",
-        "value": "1",
-        "addon_release_url": null,
-        "preferences": []
-      },
-      {
-        "description": "Standard address bar experience",
-        "is_control": true,
-        "name": "control",
-        "ratio": 50,
-        "slug": "control",
-        "value": "0",
-        "addon_release_url": null,
-        "preferences": []
-      }
-    ],
-    "changes": [
-      {
-        "changed_on": "2019-08-07T16:02:43.538514Z",
-        "pretty_status": "Created Delivery",
-        "new_status": "Draft",
-        "old_status": null
-      },
-      {
-        "changed_on": "2019-08-07T20:52:06.859236Z",
-        "pretty_status": "Edited Delivery",
-        "new_status": "Draft",
-        "old_status": "Draft"
-      }
-    ]
-  },
-  {
-    "experiment_url": "https://experimenter.services.mozilla.com/experiments/impact-of-level-2-etp-on-a-custom-distribution/",
-    "type": "pref",
-    "name": "Impact of Level 2 ETP on a Custom Distribution",
-    "slug": "impact-of-level-2-etp-on-a-custom-distribution",
-    "public_name": "Impact of Level 2 ETP",
-    "public_description": "This study enables ETP for a known population to observe impacts on usage and revenue",
-    "status": "Live",
-    "client_matching": "Prefs: n/a\r\n\r\nExperiments: none (different G plugin means we'll ignore the main ETP Level 2 experiment)\r\n\r\nAny additional filters:\r\nnormandy.distribution must be one of the following two options:\r\n* isltd-g-aura-001\r\n* isltd-g-001\r\n    \r\nLess than 200k MAU should be targeted with this filtering.",
-    "locales": [],
-    "countries": [],
-    "platform": "All Platforms",
-    "start_date": null,
-    "end_date": null,
-    "population": "100% of Release Firefox 72.0 to 80.0",
-    "population_percent": "100.0000",
-    "firefox_channel": "Release",
-    "firefox_min_version": "72.0",
-    "firefox_max_version": "80.0",
-    "addon_experiment_id": null,
-    "addon_release_url": null,
-    "pref_branch": "default",
-    "pref_name": "privacy.annotate_channels.strict_list.enabled",
-    "pref_type": "boolean",
-    "proposed_start_date": 1580169600000,
-    "proposed_enrollment": null,
-    "proposed_duration": 180,
-    "variants": [
-      {
-        "description": "this is actually the treatment branch (see background links or ask mconnor for clarity)",
-        "is_control": true,
-        "name": "treatment",
-        "ratio": 100,
-        "slug": "treatment",
-        "value": "true",
-        "addon_release_url": null,
-        "preferences": []
-      }
-    ],
-    "changes": [
-      {
-        "changed_on": "2020-01-07T15:35:19.880806Z",
-        "pretty_status": "Created Delivery",
-        "new_status": "Draft",
-        "old_status": null
-      },
-      {
-        "changed_on": "2020-01-07T15:38:15.351745Z",
-        "pretty_status": "Edited Delivery",
-        "new_status": "Draft",
-        "old_status": "Draft"
-      }
-    ]
-  },
-  {
-    "experiment_url":"https://experimenter.services.mozilla.com/experiments/doh-us-engagement-study-v2/",
-    "type":"pref",
-    "name":"DoH US Engagement Study V2",
-    "slug":"doh-us-engagement-study-v2",
-    "public_name":"DNS over HTTPS US Rollout",
-    "public_description":"This Firefox experiment will measure the impact on user engagement and retention when DNS over HTTPS is rolled out in the United States. Users who are part of the study will receive a notification before DNS over HTTPS is enabled. Set network.trr.mode to ‘5’ in about:config to permanently disable DoH. This experiment does not collect personally-identifiable information, DNS queries, or answers.",
-    "status":"Complete",
-    "client_matching":"- 69.0.3 or higher (including 70.*)\r\n- Enrollment should be sticky over country\r\n- System addon doh-rollout@mozilla.org is installed\r\n\r\nThe staged rollout will want to avoid this experiment https://experimenter.services.mozilla.com/experiments/doh-us-staged-rollout-to-all-us-desktop-users/edit/",
-    "locales":[],
-    "platform":"All Windows",
-    "start_date":1572393600000.0,
-    "end_date":1576454400000.0,
-    "population":"1% of Release Firefox 69.0 to 71.0",
-    "population_percent":"1.0000",
-    "firefox_channel":"Release",
-    "firefox_min_version":"69.0",
-    "firefox_max_version":"71.0",
-    "addon_experiment_id":"None",
-    "addon_release_url":"None",
-    "normandy_slug": "pref-doh-us-engagement-study-v2-release-69-71-bug-1590831",
-    "pref_branch":"default",
-    "pref_name":"doh-rollout.enabled",
-    "pref_type":"boolean",
-    "proposed_start_date":1572307200000.0,
-    "proposed_enrollment":7,
-    "proposed_duration":69,
-    "variants":[],
-    "changes":[]
-  }
-]
-"""  # noqa
 
 NIMBUS_EXPERIMENTER_FIXTURE = r"""
 [
@@ -456,9 +298,7 @@ FOCUS_ANDROID_EXPERIMENT_FIXTURE = """
 def mock_session():
     def experimenter_fixtures(url):
         mocked_value = MagicMock()
-        if url == ExperimentCollection.EXPERIMENTER_API_URL_V1:
-            mocked_value.json.return_value = json.loads(LEGACY_EXPERIMENTER_FIXTURE)
-        elif url == ExperimentCollection.EXPERIMENTER_API_URL_V8:
+        if url == ExperimentCollection.EXPERIMENTER_API_URL_V8:
             mocked_value.json.return_value = json.loads(NIMBUS_EXPERIMENTER_FIXTURE)
         else:
             raise Exception("Invalid Experimenter API call.")
@@ -477,9 +317,8 @@ def experiment_collection(mock_session):
 
 def test_from_experimenter(mock_session):
     collection = ExperimentCollection.from_experimenter(mock_session)
-    mock_session.get.assert_any_call(ExperimentCollection.EXPERIMENTER_API_URL_V1)
     mock_session.get.assert_any_call(ExperimentCollection.EXPERIMENTER_API_URL_V8)
-    assert len(collection.experiments) == 6
+    assert len(collection.experiments) == 3
     assert isinstance(collection.experiments[0], Experiment)
     assert isinstance(collection.experiments[0].branches[0], Branch)
     assert len(collection.experiments[0].branches) == 2
@@ -493,54 +332,24 @@ def test_started_since(experiment_collection):
     assert len(recent.experiments) > 0
 
 
-def test_normandy_experiment_slug(experiment_collection):
-    normandy_slugs = [e.normandy_slug for e in experiment_collection.experiments]
-    assert "addon-activity-stream-search-topsites-release-69-1576277" in normandy_slugs
-    assert None in normandy_slugs
-    assert "pref-doh-us-engagement-study-v2-release-69-71-bug-1590831" in normandy_slugs
-
-
 def test_with_slug(experiment_collection):
-    experiments = experiment_collection.with_slug("search-topsites")
+    experiments = experiment_collection.with_slug("bug-1629098-rapid-please-reject-me-beta-86")
     assert len(experiments.experiments) == 1
-    assert experiments.experiments[0].experimenter_slug == "search-topsites"
+    assert experiments.experiments[0].experimenter_slug is None
+    assert experiments.experiments[0].normandy_slug == "bug-1629098-rapid-please-reject-me-beta-86"
 
     experiments = experiment_collection.with_slug(
-        "addon-activity-stream-search-topsites-release-69-1576277"
+        "bug-1629000-rapid-testing-rapido-intake-1-release-79"
     )
     assert len(experiments.experiments) == 1
-    assert experiments.experiments[0].experimenter_slug == "search-topsites"
+    assert experiments.experiments[0].experimenter_slug is None
     assert (
         experiments.experiments[0].normandy_slug
-        == "addon-activity-stream-search-topsites-release-69-1576277"
+        == "bug-1629000-rapid-testing-rapido-intake-1-release-79"
     )
 
     experiments = experiment_collection.with_slug("non-existing-slug")
     assert len(experiments.experiments) == 0
-
-
-def test_convert_legacy_experiment_to_experiment():
-    legacy_experiment = LegacyExperiment(
-        slug="test-slug",
-        normandy_slug="test_slug",
-        status="Live",
-        type="cfr",
-        start_date=dt.datetime(2019, 1, 1),
-        end_date=dt.datetime(2019, 1, 10),
-        proposed_enrollment=14,
-        variants=[
-            Variant(is_control=True, slug="control", ratio=2),
-            Variant(is_control=False, slug="treatment", ratio=1),
-        ],
-    )
-
-    experiment = legacy_experiment.to_experiment()
-
-    assert experiment.experimenter_slug == "test-slug"
-    assert experiment.normandy_slug == "test_slug"
-    assert len(experiment.branches) == 2
-    assert experiment.reference_branch == "control"
-    assert experiment.is_high_population is False
 
 
 def test_convert_nimbus_experiment_to_experiment():


### PR DESCRIPTION
We don't need to ingest experiments from the v1 API because these are all Normandy, and Normandy is retired. This removes the fetching and creation of Legacy Experiments.