### PR TITLE
chore: remove monitor cirrus from apps

### DIFF
--- a/platform_config.toml
+++ b/platform_config.toml
@@ -27,6 +27,7 @@ app_id = "org.mozilla.ios.Focus"
 [platform.klar_ios]
 app_id = "org.mozilla.ios.Klar"
 
-[platform.monitor_cirrus]
-app_id = "monitor.cirrus"
-enrollments_query_type = "cirrus"
+# Disabled until web analysis is better understood.
+# [platform.monitor_cirrus]
+# app_id = "monitor.cirrus"
+# enrollments_query_type = "cirrus"


### PR DESCRIPTION
We aren't using jetstream for cirrus apps yet, and having them included could produce errors that aren't meaningful and that could be confusing to users.

/cc @jaredlockhart @yashikakhurana 

fixes #2441 