### PR TITLE
fix: get image by upload not update time

### DIFF
--- a/jetstream/tests/conftest.py
+++ b/jetstream/tests/conftest.py
@@ -273,16 +273,19 @@ def docker_images():
             name="projects/moz-fx-data-experiments/locations/us/repositories/"
             + "gcr.io/dockerImages/jetstream@sha256:8c766a",
             update_time=timestamp_pb2.Timestamp(seconds=1672578000),  # 2023-01-01 01:00 am
+            upload_time=timestamp_pb2.Timestamp(seconds=1672578000),  # 2023-01-01 01:00 am
         ),
         artifactregistry.DockerImage(
             name="projects/moz-fx-data-experiments/locations/us/repositories/"
             + "gcr.io/dockerImages/unrelated@sha256:aaaaa",
-            update_time=timestamp_pb2.Timestamp(seconds=1672578000),  # 2023-01-01 01:00 am
+            update_time=timestamp_pb2.Timestamp(seconds=1677675600),  # 2023-03-01 01:00 am
+            upload_time=timestamp_pb2.Timestamp(seconds=1672578000),  # 2023-01-01 01:00 am
         ),
         artifactregistry.DockerImage(
             name="projects/moz-fx-data-experiments/locations/us/repositories/"
             + "gcr.io/dockerImages/jetstream@sha256:xxxxx",
             update_time=timestamp_pb2.Timestamp(seconds=1677675600),  # 2023-03-01 01:00 am
+            upload_time=timestamp_pb2.Timestamp(seconds=1677675600),  # 2023-03-01 01:00 am
         ),
     ]
 

--- a/jetstream/tests/test_artifacts.py
+++ b/jetstream/tests/test_artifacts.py
@@ -33,8 +33,9 @@ class TestArtifactManager:
         artifact_client.list_docker_images.return_value = docker_images
 
         proj = "moz-fx-data-experiments"
-        artifact_manager = ArtifactManager(proj, "mozanalysis", "not-existing", artifact_client)
-        with pytest.raises(ValueError, match=f"No jetstream docker image available in {proj}"):
+        image = "not-existing"
+        artifact_manager = ArtifactManager(proj, "mozanalysis", image, artifact_client)
+        with pytest.raises(ValueError, match=f"No `{image}` docker image available in {proj}"):
             artifact_manager.latest_image()
 
     def test_image_for_date(self, docker_images):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version="2025.2.1"
 authors=[{name = "Mozilla Corporation", email="fx-data-dev@mozilla.org"}]
 description="Runs a thing that analyzes experiments"
 readme = "README.md"
-requires-python=">=3.10"
+requires-python=">=3.10,<3.11"
 dependencies=[
     "attrs",
     "cattrs",
@@ -91,17 +91,17 @@ target-version = "py310"
 [tool.ruff.lint]
 ignore= ["E741", "RUF005", "RUF012", "SIM105"]
 select = [
-    "E", # pycodestyle
-    "W", # pycodestyle
-    "F", # Pyflakes
-    "B", # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "I", # isort
-    "SIM", # flake8-simplify
-    "TCH", # flake8-type-checking
-    "TID", # flake8-tidy-imports
-    "Q", # flake8-quotes
-    "UP", # pyupgrade
-    "PT", # flake8-pytest-style
-    "RUF", # Ruff-specific rules
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "E",    # pycodestyle
+    "F",    # Pyflakes
+    "I",    # isort
+    "PT",   # flake8-pytest-style
+    "Q",    # flake8-quotes
+    "RUF",  # Ruff-specific rules
+    "SIM",  # flake8-simplify
+    "TC",   # flake8-type-checking
+    "TID",  # flake8-tidy-imports
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
 ]


### PR DESCRIPTION
I noticed that the `latest_image` fn wasn't always getting the actual latest image, and as far as I can tell it was because both the latest and previous-latest images are "updated" when the latest is uploaded: the previous-latest is updated because its tags change, i.e., the `latest` tag is removed. Using the `upload_time` instead of `update_time` should fix this, and in my testing it appears to work.

I also added a max python version, sorted the ruff rules, and fixed a renamed rule (`TCH` --> `TC`).