### PR TITLE
feat: discrete metric execution

### DIFF
--- a/jetstream/workflows/run.yaml
+++ b/jetstream/workflows/run.yaml
@@ -34,6 +34,8 @@ spec:
             value: "{{item.dates}}"
           - name: image_hash
             value: "{{item.image_hash}}"
+          - name: metric_slugs
+            value: "{{item.metric_slugs}}"
         withParam: "{{inputs.parameters.experiments}}"  # process these experiments in parallel
         continueOn:
           failed: true
@@ -44,6 +46,7 @@ spec:
         - name: image_hash
         - name: slug
         - name: dates
+        - name: metric_slugs
     steps:
       - - name: ensure-enrollments
           template: ensure-enrollments
@@ -63,6 +66,8 @@ spec:
                 value: "{{item}}"
               - name: image_hash
                 value: "{{inputs.parameters.image_hash}}"
+              - name: metric_slugs
+                value: "{{inputs.parameters.metric_slugs}}"
           withParam: "{{inputs.parameters.dates}}"
 
   - name: ensure-enrollments
@@ -85,12 +90,14 @@ spec:
       - name: image_hash
       - name: date
       - name: slug
+      - name: metric_slug
     container:
       image: gcr.io/moz-fx-data-experiments/{{workflow.parameters.image}}@sha256:{{inputs.parameters.image_hash}}
       command: [
         jetstream, --log_to_bigquery, run,
         "--date={{inputs.parameters.date}}",
         "--experiment_slug={{inputs.parameters.slug}}",
+        "--metric-slug={{inputs.parameters.metric_slug}}",
         "--dataset_id={{workflow.parameters.dataset_id}}", 
         "--project_id={{workflow.parameters.project_id}}",
         "--bucket={{workflow.parameters.bucket}}", 
@@ -137,6 +144,7 @@ spec:
         - name: slug
         - name: date
         - name: image_hash
+        - name: metric_slugs
     steps:
     - - name: analyse-experiment
         template: analyse-experiment  
@@ -148,6 +156,9 @@ spec:
             value: "{{inputs.parameters.date}}"
           - name: image_hash
             value: "{{inputs.parameters.image_hash}}"
+          - name: metric_slug
+            value: "{{item}}"
+        withParam: "{{inputs.parameters.metric_slugs}}"
     - - name: export-statistics
         template: export-statistics
         arguments:

--- a/requirements.in
+++ b/requirements.in
@@ -184,7 +184,7 @@ matplotlib==3.10.0
     #   plotnine
 mizani==0.13.1
     # via plotnine
-mozanalysis==2025.2.1
+mozanalysis==2025.3.1
     # via mozilla-jetstream
 mozilla-metric-config-parser==2024.11.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -958,8 +958,8 @@ mizani==0.13.1 \
     # via
     #   -r requirements.in
     #   plotnine
-mozanalysis==2025.2.1 \
-    --hash=sha256:55b4bed955859fb30b95576a072261ba58a94913496590d0cb05c01acc479085
+mozanalysis==2025.3.1 \
+    --hash=sha256:a52ccbd9df903d7b8b37baa48b024d5633b6e4087a9a2758620f2894b7b53605
     # via -r requirements.in
 mozilla-metric-config-parser==2024.11.1 \
     --hash=sha256:4f972b669cdaefc1ff5e7372a93bbd23151d7bbdf8f3dbe2b4c3ff4ab61b33bb


### PR DESCRIPTION
Some main points:
* adds `--metric-slug` parameter to CLI run commands
* passes metric slugs to executors to filter the config
* passes metric slugs to argo config for each experiment
* expects metric-per-row in metrics tables
* pivots metric-per-row to previous format for statistics computations


WIP: 
* the big one is to ensure this doesn't break when it's deployed alongside existing Jetstream (esp because Argo config changed)
* there's a lot of print statements and general clean-up that I need to do
* need to update tests and write new ones
* I will also write up a doc detailing validation and performance testing I've done so that we can be confident in the changes