### PR TITLE
fix: use analysis_id for preview enrollments

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1553,5 +1553,5 @@ def preview(
 
         click.echo(
             "A preview is available at: "
-            + f"{LOOKER_PREVIEW_URL}?Project='{project_id}'&Dataset='{dataset_id}'&Slug='{table}'"
+            + f"{LOOKER_PREVIEW_URL}?Project={project_id}&Dataset={dataset_id}&Slug={table}"
         )


### PR DESCRIPTION
- preview support for profiles by using `analysis_id` in the sampled enrollment queries
- switch to `events_stream` for glean sampled enrollment query
- fix preview link by removing single quotes around filter fields