### PR TITLE
fix: log actual slug with config resolve error

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -392,7 +392,9 @@ class AnalysisExecutor:
             # errors without failing, and continue execution for successful experiments
             results = {}
             for experiment in experiments:
-                results[experiment.normandy_slug] = pool.apply_async(_load_experiment_config, args=(experiment,))
+                results[experiment.normandy_slug] = pool.apply_async(
+                    _load_experiment_config, args=(experiment,)
+                )
 
             for slug, result in results.items():
                 try:
@@ -404,9 +406,7 @@ class AnalysisExecutor:
                     DefinitionNotFound,
                     UnexpectedKeyConfigurationException,
                 ) as e:
-                    logger.exception(
-                        str(e), exc_info=e, extra={"experiment": slug}
-                    )
+                    logger.exception(str(e), exc_info=e, extra={"experiment": slug})
 
         return configs
 

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -390,11 +390,11 @@ class AnalysisExecutor:
         with ThreadPool() as pool:
             # this is the same functionality as pool.map except we can catch and log
             # errors without failing, and continue execution for successful experiments
-            results = []
+            results = {}
             for experiment in experiments:
-                results.append(pool.apply_async(_load_experiment_config, args=(experiment,)))
+                results[experiment.normandy_slug] = pool.apply_async(_load_experiment_config, args=(experiment,))
 
-            for result in results:
+            for slug, result in results.items():
                 try:
                     configs.append(result.get())
                 except (
@@ -405,7 +405,7 @@ class AnalysisExecutor:
                     UnexpectedKeyConfigurationException,
                 ) as e:
                     logger.exception(
-                        str(e), exc_info=e, extra={"experiment": experiment.normandy_slug}
+                        str(e), exc_info=e, extra={"experiment": slug}
                     )
 
         return configs


### PR DESCRIPTION
Saw an error from here that appeared to be getting logged with the wrong experiment, and I think it's because we're logging the last experiment in the list, so if there is an error when originally resolving all experiments' configs then it would be logged with the last experiment's slug.