### PR TITLE
feat: request single slug from Exp API when possible

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -418,7 +418,10 @@ class AnalysisExecutor:
         config_getter: _ConfigLoader = ConfigLoader,
     ) -> list[AnalysisConfiguration]:
         """Fetch configs of experiments that are to be analysed."""
-        experiments = experiment_getter()
+        if not isinstance(self.experiment_slugs, AllType) and len(self.experiment_slugs) == 1:
+            experiments = experiment_getter(slug=self.experiment_slugs[0])
+        else:
+            experiments = experiment_getter()
         run_configs = []
 
         if isinstance(self.experiment_slugs, AllType):
@@ -1513,7 +1516,9 @@ def preview(
             config_getter=ConfigLoader.with_configs_from(config_repos).with_configs_from(
                 private_config_repos, is_private=True
             ),
-            experiment_getter=lambda exp=experiment: ExperimentCollection(experiments=[exp]),
+            experiment_getter=lambda exp=experiment, slug=None: ExperimentCollection(
+                experiments=[exp]
+            ),
         )
 
         # run preview analysis
@@ -1541,14 +1546,16 @@ def preview(
                     log_config,
                     analysis_periods=analysis_periods,
                     sql_output_dir=sql_output_dir,
-                    experiment_getter=lambda exp=experiment: ExperimentCollection(
+                    experiment_getter=lambda exp=experiment, slug=None: ExperimentCollection(
                         experiments=[exp]
                     ),
                 ),
                 config_getter=ConfigLoader.with_configs_from(config_repos).with_configs_from(
                     private_config_repos, is_private=True
                 ),
-                experiment_getter=lambda exp=experiment: ExperimentCollection(experiments=[exp]),
+                experiment_getter=lambda exp=experiment, slug=None: ExperimentCollection(
+                    experiments=[exp]
+                ),
             )
 
         click.echo(

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime, time, timedelta
 from functools import partial
 from importlib.metadata import version
@@ -103,7 +103,7 @@ class ArgoExecutorStrategy:
     bucket: str | None = None
     cluster_ip: str | None = None
     cluster_cert: str | None = None
-    experiment_getter: Callable[[], ExperimentCollection] = ExperimentCollection.from_experimenter
+    experiment_getter: Callable[..., ExperimentCollection] = ExperimentCollection.from_experimenter
     analysis_periods: list[AnalysisPeriod] = ALL_PERIODS
     image: str = "jetstream"
     image_version: str | None = None
@@ -209,7 +209,7 @@ class SerialExecutorStrategy:
     bucket: str | None = None
     log_config: LogConfiguration | None = None
     analysis_class: type = Analysis
-    experiment_getter: Callable[[], ExperimentCollection] = ExperimentCollection.from_experimenter
+    experiment_getter: Callable[..., ExperimentCollection] = ExperimentCollection.from_experimenter
     config_getter: _ConfigLoader = ConfigLoader
     analysis_periods: list[AnalysisPeriod] = ALL_PERIODS
     sql_output_dir: str | None = None
@@ -290,7 +290,7 @@ class AnalysisExecutor:
     dataset_id: str
     bucket: str
     date: datetime | AllType
-    experiment_slugs: Iterable[str] | AllType
+    experiment_slugs: Sequence[str] | AllType
     configuration_map: Mapping[str, TextIO | AnalysisSpec] | None = attr.ib(None)
     recreate_enrollments: bool = False
     sql_output_dir: str | None = None
@@ -309,7 +309,7 @@ class AnalysisExecutor:
         strategy: ExecutorStrategy,
         *,
         experiment_getter: Callable[
-            [], ExperimentCollection
+            ..., ExperimentCollection
         ] = ExperimentCollection.from_experimenter,
         config_getter: _ConfigLoader = ConfigLoader,
         today: datetime | None = None,
@@ -413,7 +413,7 @@ class AnalysisExecutor:
     def _experiment_configs_to_analyse(
         self,
         experiment_getter: Callable[
-            [], ExperimentCollection
+            ..., ExperimentCollection
         ] = ExperimentCollection.from_experimenter,
         config_getter: _ConfigLoader = ConfigLoader,
     ) -> list[AnalysisConfiguration]:
@@ -478,7 +478,7 @@ class AnalysisExecutor:
         self,
         config_getter: _ConfigLoader = ConfigLoader,
         experiment_getter: Callable[
-            [], ExperimentCollection
+            ..., ExperimentCollection
         ] = ExperimentCollection.from_experimenter,
     ) -> None:
         """Ensure that enrollment tables for experiment are up-to-date or re-create."""

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import logging
 from collections.abc import Iterable
+from urllib.parse import urljoin
 
 import attr
 import cattr
@@ -149,8 +150,8 @@ class ExperimentCollection:
         url = cls.EXPERIMENTER_API_URL_V8
         draft_url = cls.EXPERIMENTER_API_URL_V8_DRAFTS
         if slug:
-            url = url + slug + "/"
-            draft_url = draft_url + slug + "/"
+            url = urljoin(url, slug) + "/"
+            draft_url = urljoin(draft_url, slug) + "/"
 
         nimbus_experiments_json = retry_get(session, url, cls.MAX_RETRIES, cls.USER_AGENT)
         if slug:

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -139,13 +139,20 @@ class ExperimentCollection:
 
     @classmethod
     def from_experimenter(
-        cls, session: requests.Session = None, with_draft_experiments=False
+        cls,
+        session: requests.Session = None,
+        with_draft_experiments=False,
+        slug=None,
     ) -> "ExperimentCollection":
         session = session or requests.Session()
 
-        nimbus_experiments_json = retry_get(
-            session, cls.EXPERIMENTER_API_URL_V8, cls.MAX_RETRIES, cls.USER_AGENT
-        )
+        url = cls.EXPERIMENTER_API_URL_V8
+        draft_url = cls.EXPERIMENTER_API_URL_V8_DRAFTS
+        if slug:
+            url = url + slug + "/"
+            draft_url = draft_url + slug + "/"
+
+        nimbus_experiments_json = retry_get(session, url, cls.MAX_RETRIES, cls.USER_AGENT)
         nimbus_experiments = []
 
         for nimbus_experiment in nimbus_experiments_json:
@@ -161,9 +168,7 @@ class ExperimentCollection:
         draft_experiments = []
         if with_draft_experiments:
             # draft experiments are mainly used to compute previews
-            draft_experiments_json = retry_get(
-                session, cls.EXPERIMENTER_API_URL_V8_DRAFTS, cls.MAX_RETRIES, cls.USER_AGENT
-            )
+            draft_experiments_json = retry_get(session, draft_url, cls.MAX_RETRIES, cls.USER_AGENT)
 
             for draft_experiment in draft_experiments_json:
                 try:

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -164,9 +164,14 @@ class ExperimentCollection:
                     NimbusExperiment.from_dict(nimbus_experiment).to_experiment()
                 )
             except Exception as e:
-                logger.exception(
-                    str(e), exc_info=e, extra={"experiment": nimbus_experiment["slug"]}
-                )
+                if "slug" in nimbus_experiment:
+                    logger.exception(
+                        str(e), exc_info=e, extra={"experiment": nimbus_experiment["slug"]}
+                    )
+                elif slug:
+                    logger.exception(str(e), exc_info=e, extra={"experiment": slug})
+                else:
+                    logger.exception(str(e), exc_info=e)
 
         draft_experiments = []
         if with_draft_experiments:

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -153,6 +153,8 @@ class ExperimentCollection:
             draft_url = draft_url + slug + "/"
 
         nimbus_experiments_json = retry_get(session, url, cls.MAX_RETRIES, cls.USER_AGENT)
+        if slug:
+            nimbus_experiments_json = [nimbus_experiments_json]
         nimbus_experiments = []
 
         for nimbus_experiment in nimbus_experiments_json:
@@ -169,6 +171,8 @@ class ExperimentCollection:
         if with_draft_experiments:
             # draft experiments are mainly used to compute previews
             draft_experiments_json = retry_get(session, draft_url, cls.MAX_RETRIES, cls.USER_AGENT)
+            if slug:
+                draft_experiments_json = [draft_experiments_json]
 
             for draft_experiment in draft_experiments_json:
                 try:

--- a/jetstream/tests/integration/test_experimenter_api.py
+++ b/jetstream/tests/integration/test_experimenter_api.py
@@ -5,14 +5,25 @@ from jetstream.experimenter import ExperimentCollection
 
 
 @pytest.fixture
-def experiment_collection():
+def experiment_collection(request):
     try:
-        collection = ExperimentCollection.from_experimenter()
+        collection = ExperimentCollection.from_experimenter(slug=request.param)
         return collection
     except Exception as e:
         pytest.fail(f"Failed to fetch experiment collection: {e!s}")
 
 
+@pytest.mark.parametrize("experiment_collection", [None], indirect=["experiment_collection"])
 def test_from_experimenter(experiment_collection):
+    assert len(experiment_collection.experiments) > 1
     for experiment in experiment_collection.experiments:
         assert isinstance(experiment, Experiment)
+
+
+@pytest.mark.parametrize(
+    "experiment_collection", ["automated-segments-test-1"], indirect=["experiment_collection"]
+)
+def test_from_experimenter_with_slug(experiment_collection):
+    experiments = experiment_collection.experiments
+    assert len(experiments) == 1
+    assert isinstance(experiments[0], Experiment)

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -24,8 +24,8 @@ def cli_experiment_fixture():
     return cli_experiments()
 
 
-def cli_experiments():
-    return experimenter.ExperimentCollection(
+def cli_experiments(slug=None):
+    collection = experimenter.ExperimentCollection(
         [
             Experiment(
                 experimenter_slug=None,
@@ -64,13 +64,18 @@ def cli_experiments():
         ]
     )
 
+    if slug:
+        return collection.with_slug(slug=slug)
+
+    return collection
+
 
 @pytest.fixture(name="cli_experiments_enrollment_incomplete")
 def cli_experiment_enrollment_fixture():
     return cli_experiments_enrollment_incomplete()
 
 
-def cli_experiments_enrollment_incomplete():
+def cli_experiments_enrollment_incomplete(slug=None):
     return experimenter.ExperimentCollection(
         [
             Experiment(


### PR DESCRIPTION
This is intended to alleviate some load on the Experimenter API that appears to be leading to increasing errors in Jetstream when attempting to request experiment data. The assumption is that at least some of the problem stems from the ever-increasing number of experiments in Experimenter, and the fact that jetstream naively requests all of them and figures out the important ones after-the-fact.

This fix makes it so jetstream can request a specific experiment's config when a slug is configured (e.g., when run manually, or for each workflow launched from the daily airflow task).

I considered iterating over the slugs whenever it wasn't `AllType`, but am a bit wary of running an arbitrary number of API requests, and I think this more specific solution should cover the most common scenarios anyway.

Fixes #2589 