### PR TITLE
fix: use specific slug to get last_updated dates

### DIFF
--- a/jetstream/bigquery_client.py
+++ b/jetstream/bigquery_client.py
@@ -215,7 +215,7 @@ class BigQueryClient:
                 ) AS last_updated
             FROM
             {self.dataset}.INFORMATION_SCHEMA.TABLE_OPTIONS
-            WHERE option_name = 'labels' AND table_name LIKE "enrollments_{table_prefix}%"
+            WHERE option_name = 'labels' AND table_name = "enrollments_{table_prefix}"
             """
         )
         result = list(job.result())

--- a/jetstream/config.py
+++ b/jetstream/config.py
@@ -175,7 +175,9 @@ class _ConfigLoader:
                     dt.datetime.utcfromtimestamp(int(row.last_updated[0]))
                 )
                 if table_last_updated < default_config.last_modified:
-                    updated_experiments.append(row.normandy_slug)
+                    table_desc = client.get_table(f"{bq_dataset}.{row.table_name}").description
+                    if table_desc == row.normandy_slug:
+                        updated_experiments.append(row.normandy_slug)
 
         return list(set(updated_experiments))
 


### PR DESCRIPTION
Found another instance of the fuzzy match getting the wrong date. In this case it was in `experiment_table_first_updated`, but went and looked for other possibilities and so I also updated `updated_defaults` similarly to `updated_configs` that I updated previously.