### PR TITLE
chore: improve validate fetch and error logging

### DIFF
--- a/jetstream/bigquery_client.py
+++ b/jetstream/bigquery_client.py
@@ -9,7 +9,6 @@ import google.cloud.bigquery
 import google.cloud.bigquery.client
 import google.cloud.bigquery.dataset
 import google.cloud.bigquery.job
-import google.cloud.bigquery.table
 import numpy as np
 import pandas as pd
 from google.cloud.bigquery_storage import BigQueryReadClient

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1202,7 +1202,6 @@ def rerun_config_changed(
 def validate_config(path: Iterable[os.PathLike], config_repos, private_config_repos, is_private):
     """Validate config files."""
     dirty = False
-    collection = ExperimentCollection.from_experimenter()
 
     for config_file in path:
         config_file = Path(config_file)
@@ -1231,7 +1230,8 @@ def validate_config(path: Iterable[os.PathLike], config_repos, private_config_re
             and not isinstance(entity, DefaultConfig)
             and not isinstance(entity, DefinitionConfig)
         ):
-            if (experiments := collection.with_slug(entity.slug).experiments) == []:
+            experiments = ExperimentCollection.from_experimenter(slug=entity.slug).experiments
+            if experiments == []:
                 print(f"No experiment with slug {entity.slug} in Experimenter.")
                 dirty = True
                 continue

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -164,14 +164,15 @@ class ExperimentCollection:
                     NimbusExperiment.from_dict(nimbus_experiment).to_experiment()
                 )
             except Exception as e:
+                msg = f"{e} (Response object: {nimbus_experiment})"
                 if "slug" in nimbus_experiment:
                     logger.exception(
-                        str(e), exc_info=e, extra={"experiment": nimbus_experiment["slug"]}
+                        msg, exc_info=e, extra={"experiment": nimbus_experiment["slug"]}
                     )
                 elif slug:
-                    logger.exception(str(e), exc_info=e, extra={"experiment": slug})
+                    logger.exception(msg, exc_info=e, extra={"experiment": slug})
                 else:
-                    logger.exception(str(e), exc_info=e)
+                    logger.exception(msg, exc_info=e)
 
         draft_experiments = []
         if with_draft_experiments:
@@ -186,7 +187,7 @@ class ExperimentCollection:
                         NimbusExperiment.from_dict(draft_experiment).to_experiment()
                     )
                 except Exception as e:
-                    print(f"Error converting draft experiment {draft_experiment['slug']}")
+                    print(f"Error converting draft experiment {draft_experiment}")
                     print(str(e))
 
         return cls(nimbus_experiments + draft_experiments)


### PR DESCRIPTION
Some QOL improvements:
- fetch by slug when possible in validate (cli)
- don't fetch from API at all if not needed (cli)
- remove unused import (bigquery_client)
- improve error logging (experimenter)

fixes #2631 