### PR TITLE
chore: cli param consistent name with var for glean ids

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -778,7 +778,7 @@ statistics_only_option = click.option(
     default=False,
 )
 
-use_glean_ids_option = click.option("--glean-only", is_flag=True, default=False)
+use_glean_ids_option = click.option("--use-glean-ids", "--glean-only", is_flag=True, default=False)
 
 
 @cli.command()


### PR DESCRIPTION
I realized that this was a little odd and might cause confusion, so added an additional alias for this flag to match the variable used everywhere else.