### PR TITLE
feat: ability to compute metrics discretely

### DIFF
--- a/docs/adr-0003-discrete_metrics_table_structure.md
+++ b/docs/adr-0003-discrete_metrics_table_structure.md
@@ -3,6 +3,7 @@
 * Status: accepting feedback
 * Deciders: mikewilli, scholtzan, danielkberry
 * Date: 2024-11-08
+* Updated: 2025-04-24
 
 
 ## Context and Problem Statement
@@ -20,7 +21,9 @@ We want Jetstream to support discrete metric execution ([proposal doc](https://g
 
 ## Decision Outcome
 
-**Option 2** is the chosen option. We can preserve the schemas of the views by pivoting the results tables, and we save a lot on complexity during normal execution as compared to Option 1. Option 3 is very similar but creates additional clutter in the form of many tables.
+**Option 3** is the chosen option.
+
+We can preserve the data type of the metric values in BigQuery, and the schema broadly stays the same (client info + column for metric values -- though split across many tables). Option 2 is very similar, but pivots the data so that it can be stored row-wise in a single table (metric_slug: metric_value), and importantly requires many additional DML operations to delete existing metric results because it cannot simply truncate the entire table on each write like we do now, and can do in Option 3.
 
 
 ## Options
@@ -58,6 +61,7 @@ For each option, we will use the following scenario as an example for describing
 * **+** This preserves the existing table structure
 * **-** Lots of added complexity
 * **-** Added cost (BigQuery treats each MERGE as basically a full delete/recreate of the table)
+* **-** Adds many DML operations, BigQuery limits how many can be queued concurrently
 
 
 ### 2. Row per Metric
@@ -86,20 +90,24 @@ For each option, we will use the following scenario as an example for describing
 #### Pros / Cons
 
 * **+** Low complexity of logic
-* **+** Only need to process new data for INSERTs
-* **-** This breaks backwards compatibility with the current tables schemas (mitigated by view schema remaining the same)
+* **+** Only need to process new data for INSERTs (but need to do DELETEs beforehand)
+* **-** This breaks backwards compatibility with the current tables schemas (mitigated if view schema remains the same)
 * **-** Redundancy in table for repeated client info columns
 * **-** Added cost for reruns (DELETE statements in BigQuery require reprocessing all data)
+* **-** Pivoting table into view (to preserve existing schema) is complicated
+* **-** Adds many DML operations, BigQuery limits how many can be queued concurrently
   
 
 ### 3. Table per Metric
 
-* This option is almost identical to the [Row per Metric](#2.-Row-per-Metric) option, however instead of adding rows to an existing table, we will create a new table for each metric
+* This option is almost identical to the [Row per Metric](#2.-Row-per-Metric) option, however instead of adding rows to an existing table, we will create a new table for each metric (or, for removal of metrics, delete the metric table)
 * The `metric_slug` column from Option 2 is not necessary, so we can retain the current column-named-with-metric-slug, but each table will only ever have one of these metric columns.
+* We can concatenate the metric results and statistics results into the views as they exist now
 
 #### Pros / Cons
 
 * **+** Low complexity of logic
-* **-** This breaks backwards compatibility with the current tables schemas (mitigated by view schema remaining the same)
-* **-** Redundancy in table for repeated client info columns
-* **-** Lots of added clutter in the form of many new tables
+* **+** No DML operations, just write with WRITE_TRUNCATE when writing to metric tables
+* **-** This breaks backwards compatibility with the current single metrics table (mitigated if view schema remains the same)
+* **-** Redundancy across tables for repeated client info columns
+* **-** Lots of added clutter in the form of many new tables (1 metrics table + 1 statistics table vs table per metric + table per metric for statistics)

--- a/docs/proposal-0008-infra_updates.md
+++ b/docs/proposal-0008-infra_updates.md
@@ -1,0 +1,16 @@
+# Analysis Infrastructure Updates
+
+## Context
+
+- project was largely (if not entirely) configured by hand
+- no staging environment
+- difficult to test changes to infra
+- difficult to manage infra
+
+## Ideas
+
+- infra as code
+- staging env (or at least stage cluster)
+- exposed Argo UI
+  - see exposed ArgoCD from SRE
+  - this looks simple but is an example of difficult to test without a risk to prod cluster

--- a/jetstream/logging/__init__.py
+++ b/jetstream/logging/__init__.py
@@ -12,6 +12,7 @@ class LOG_SOURCE(str, Enum):
     JETSTREAM = "jetstream"
     SIZING = "sizing"
     PREVIEW = "jetstream-preview"
+    TESTING = "jetstream-testing"
 
 
 @attr.s(auto_attribs=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name= "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version="2025.2.1"
+version="2025.6.1"
 authors=[{name = "Mozilla Corporation", email="fx-data-dev@mozilla.org"}]
 description="Runs a thing that analyzes experiments"
 readme = "README.md"


### PR DESCRIPTION
* creates one table per metric for discrete metrics
* adds logic to make discrete metric execution optional (and not the default)
* updates the ADR to reflect this PR using option 3

WIP
TODO:
* add flag in CLI so that discrete metrics can be used (TBD, might be better to split this out into a follow-up)
* update mozanalysis once https://github.com/mozilla/mozanalysis/pull/512 is merged (and a new version is deployed)