### PR TITLE
chore: fully qualify enrollments table in metrics query

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -308,7 +308,7 @@ class Analysis:
             metrics_sql = exp.build_metrics_query(
                 metrics,
                 last_window_limits,
-                enrollments_table_name,
+                f"{self.project}.{self.dataset}.{enrollments_table_name}",
                 analysis_basis,
                 exposure_signal,
             )


### PR DESCRIPTION
Every time I look up a metrics query to investigate issues, I have to manually add in the dataset for it to be valid. This fully qualifies it for convenience.