### PR TITLE
chore: push version 2025.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name= "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version="2025.2.1"
+version="2025.7.1"
 authors=[{name = "Mozilla Corporation", email="fx-data-dev@mozilla.org"}]
 description="Runs a thing that analyzes experiments"
 readme = "README.md"


### PR DESCRIPTION
validate fails for users running jetstream locally because of the changes to the dry run function. Pushing a new version with the latest changes should fix it.