### PR TITLE
chore: refactor table metadata updates

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -997,6 +997,7 @@ class Analysis:
                 statistics_table,
                 job_config=job_config,
                 experiment_slug=self.config.experiment.normandy_slug,
+                labels={"schema_version": StatisticResult.SCHEMA_VERSION},
             )
         except BadRequest as e:
             # There was a mismatch between the segment_results root dict
@@ -1011,10 +1012,6 @@ class Analysis:
             # logger.error(f"Data received: {segment_results}")
             ve = ValueError(error_msg)
             raise ve from e
-
-        self.bigquery.add_metadata_to_table(
-            statistics_table, {"schema_version": StatisticResult.SCHEMA_VERSION}
-        )
 
     def run(
         self,

--- a/jetstream/tests/integration/test_bigquery_client.py
+++ b/jetstream/tests/integration/test_bigquery_client.py
@@ -146,9 +146,21 @@ class TestBigQueryClient:
 
         table = "statistics_test_experiment_week_1"
 
-        client.load_table_from_json(test_data.model_dump(warnings=False), table, job_config)
+        client.load_table_from_json(
+            test_data.model_dump(warnings=False),
+            table,
+            job_config,
+            experiment_slug="test-slug",
+            labels={"schema_version": StatisticResult.SCHEMA_VERSION},
+        )
 
         table_ref = client.client.get_table(f"{temporary_dataset}.{table}")
+
+        assert table_ref.description == "test-slug"
+        assert table_ref.labels
+        assert "last_updated" in table_ref.labels
+        assert "schema_version" in table_ref.labels
+
         rows = client.client.list_rows(table_ref)
         results = list(rows)
 


### PR DESCRIPTION
* combines the `"schema_version"` label with `"last_updated"` for statistics tables
* moves table `description` into the `LoadJobConfig` so it is not affected if metadata update fails
* updates test;

fixes #2735 