### PR TITLE
Use JETSTREAM_PAT instead of GITHUB_TOKEN for auto-approving and merging dependabot PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -127,10 +127,10 @@ jobs:
       - id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.JETSTREAM_PAT }}"
       - run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JETSTREAM_PAT }}


### PR DESCRIPTION
I added a personal token under `JETSTREAM_PAT` for both GH Actions and the dependabot context. This should solve the issue in https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions that results in auto-merged dependabot PRs getting stuck in the merge queue