### PR TITLE
Stop auto-merge for dependabot PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -130,7 +130,7 @@ jobs:
           github-token: "${{ secrets.JETSTREAM_PAT }}"
       - run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.JETSTREAM_PAT }}


### PR DESCRIPTION
This should resolve the issue we are seeing:
`GraphQL: Resource not accessible by personal access token (enablePullRequestAutoMerge)`

--auto calls the GraphQL mutation enablePullRequestAutoMerge under the hood, which shouldn't be needed