### PR TITLE
Call GraphQL API to enqueue dependabot PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -128,9 +128,26 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.JETSTREAM_PAT }}"
-      - run: |
-          gh pr review --approve "$PR_URL"
-          gh pr merge "$PR_URL"
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.JETSTREAM_PAT }}
+          GH_TOKEN: ${{ secrets.JETSTREAM_PAT }}
+
+      - name: Enqueue PR into merge queue (GraphQL)
+        env:
+          GH_TOKEN: ${{ secrets.JETSTREAM_PAT }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          PR_ID=$(gh api graphql -f query='
+            query($o:String!,$r:String!,$n:Int!){
+              repository(owner:$o,name:$r){ pullRequest(number:$n){ id } }
+            }' -F o="$OWNER" -F r="$REPO" -F n="$PR_NUMBER" --jq '.data.repository.pullRequest.id')
+
+          gh api graphql -f query='
+            mutation($id:ID!){
+              enqueuePullRequest(input:{pullRequestId:$id}){ mergeQueueEntry { id state } }
+            }' -F id="$PR_ID"


### PR DESCRIPTION
Use the merge queue GraphQL mutation directly. This never calls enablePullRequestAutoMerge.