### PR TITLE
Remove dependabot CI step

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -115,39 +115,3 @@ jobs:
           image_repo_host: gcr.io
           image_repo_path: moz-fx-data-experiments/jetstream
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
-
-  dependabot:
-    needs: [build, integration]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'mozilla/jetstream'
-    steps:
-      - id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: "${{ secrets.JETSTREAM_PAT }}"
-
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.JETSTREAM_PAT }}
-
-      - name: Enqueue PR into merge queue (GraphQL)
-        env:
-          GH_TOKEN: ${{ secrets.JETSTREAM_PAT }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          PR_ID=$(gh api graphql -f query='
-            query($o:String!,$r:String!,$n:Int!){
-              repository(owner:$o,name:$r){ pullRequest(number:$n){ id } }
-            }' -F o="$OWNER" -F r="$REPO" -F n="$PR_NUMBER" --jq '.data.repository.pullRequest.id')
-
-          gh api graphql -f query='
-            mutation($id:ID!){
-              enqueuePullRequest(input:{pullRequestId:$id}){ mergeQueueEntry { id state } }
-            }' -F id="$PR_ID"


### PR DESCRIPTION
Since the PAT doesn't have permissions to merge PRs, removing the dependabot CI step to not have so many failures show up. The only way seems to be creating a new Github App. I'll look into this some time in the future.