### PR TITLE
feat: add bytes processed to validation logs

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -906,9 +906,12 @@ class Analysis:
 
         self._write_sql_output(f"enrollments_{bq_normalize_name(experiment_slug)}", enrollments_sql)
 
-        dry_run_query(enrollments_sql)
+        bytes_processed = dry_run_query(enrollments_sql)
         logger.info(f"Dry running enrollments query for {experiment_slug}:")
         logger.info(enrollments_sql)
+        if bytes_processed and bytes_processed > 0:
+            tb_processed = bytes_processed / 1024 / 1024 / 1024 / 1024
+            logger.info(f"Enrollments query will process {round(tb_processed, 2)} TB")
 
         if not metric_slugs:
             output_loc = f"metrics_{bq_normalize_name(experiment_slug)}"
@@ -975,8 +978,12 @@ class Analysis:
 
         self._write_sql_output(output_loc, metrics_sql)
 
-        dry_run_query(metrics_sql)
+        bytes_processed = dry_run_query(metrics_sql)
         logger.info(metrics_sql)
+
+        if bytes_processed and bytes_processed > 0:
+            tb_processed = bytes_processed / 1024 / 1024 / 1024 / 1024
+            logger.info(f"Metrics query will process {round(tb_processed, 2)} TB")
 
     @dask.delayed
     def save_statistics(

--- a/jetstream/dryrun.py
+++ b/jetstream/dryrun.py
@@ -60,7 +60,7 @@ class DryRunFailedError(Exception):
         super().__init__(error)
 
 
-def dry_run_query(sql: str) -> None:
+def dry_run_query(sql: str) -> int:
     """Dry run the provided SQL query."""
     try:
         # look for token created by the GitHub Actions workflow
@@ -109,7 +109,7 @@ def dry_run_query(sql: str) -> None:
 
     if response["valid"]:
         logger.info("Dry run OK")
-        return
+        return int(response.get("bytesProcessed", -1))
 
     error = response["errors"][0] if "errors" in response and len(response["errors"]) == 1 else None
 
@@ -123,6 +123,6 @@ def dry_run_query(sql: str) -> None:
         # we expect CREATE VIEW and CREATE TABLE to throw specific
         # exceptions.
         logger.info("Dry run OK")
-        return
+        return int(response.get("bytesProcessed", -1))
 
     raise DryRunFailedError((error and error.get("message", None)) or response["errors"], sql=sql)

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -81,6 +81,7 @@ def test_get_timelimits_if_ready(experiments):
 
 def test_validate_doesnt_explode(experiments, monkeypatch):
     m = Mock()
+    m.return_value = -1
     monkeypatch.setattr(jetstream.analysis, "dry_run_query", m)
     x = experiments[0]
     config = AnalysisSpec.default_for_experiment(x, ConfigLoader.configs).resolve(
@@ -92,6 +93,7 @@ def test_validate_doesnt_explode(experiments, monkeypatch):
 
 def test_validate_doesnt_explode_discrete_metric(experiments, monkeypatch):
     m = Mock()
+    m.return_value = -1
     monkeypatch.setattr(jetstream.analysis, "dry_run_query", m)
     x = experiments[0]
     config = AnalysisSpec.default_for_experiment(x, ConfigLoader.configs).resolve(
@@ -206,6 +208,7 @@ def test_fenix_experiments_use_right_datasets(fenix_experiments, monkeypatch):
             dataset = re.sub(r"[^A-Za-z0-9_]", "_", exp.app_id)
             assert dataset in query
             assert query.count(dataset) == query.count("org_mozilla")
+            return -1
 
         monkeypatch.setattr("jetstream.analysis.dry_run_query", dry_run_query)
         config = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs).resolve(
@@ -225,6 +228,7 @@ def test_firefox_ios_experiments_use_right_datasets(firefox_ios_experiments, mon
             dataset = re.sub(r"[^A-Za-z0-9_]", "_", exp.app_id).lower()
             assert dataset in query
             assert query.count(dataset) == query.count("org_mozilla_ios")
+            return -1
 
         monkeypatch.setattr("jetstream.analysis.dry_run_query", dry_run_query)
         config = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs).resolve(
@@ -244,6 +248,7 @@ def test_focus_android_experiments_use_right_datasets(focus_android_experiments,
             dataset = re.sub(r"[^A-Za-z0-9_]", "_", exp.app_id).lower()
             assert dataset in query
             assert query.count(dataset) == query.count("org_mozilla_focus")
+            return -1
 
         monkeypatch.setattr("jetstream.analysis.dry_run_query", dry_run_query)
         config = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs).resolve(
@@ -263,6 +268,7 @@ def test_klar_android_experiments_use_right_datasets(klar_android_experiments, m
             dataset = re.sub(r"[^A-Za-z0-9_]", "_", exp.app_id).lower()
             assert dataset in query
             assert query.count(dataset) == query.count("org_mozilla_klar")
+            return -1
 
         monkeypatch.setattr("jetstream.analysis.dry_run_query", dry_run_query)
         config = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs).resolve(


### PR DESCRIPTION
I recently added bytes processed to the dry run function's return value, so we can use it here. This is useful for running locally as well as in metric-hub CI.

fixes #2799 