### PR TITLE
chore: tell argo to archive logs

### DIFF
--- a/jetstream/workflows/run.yaml
+++ b/jetstream/workflows/run.yaml
@@ -7,7 +7,7 @@ spec:
   archiveLogs: true
   ttlStrategy:
     secondsAfterCompletion: 4320000 # delete workflows automatically after 50 days
-    secondsAfterSuccess: 432000 # delete successful workflows automatically after 5 days
+    secondsAfterSuccess: 1296000 # delete successful workflows automatically after 15 days
   arguments:
     parameters:
     - name: experiments  # set dynamically when workflow gets deployed


### PR DESCRIPTION
Any time a pod has failed more than a couple days ago, the logs are usually not visible in the Argo UI. I think this will help make those visible longer.

From the [docs](https://argo-workflows.readthedocs.io/en/latest/configure-archive-logs/):
>This feature is provided as a convenience to quickly view logs of garbage collected Pods in the Argo UI

I also updated the TTL strategy to keep successful runs for 15 days instead of 5.