### PR TITLE
Revert "chore: tell argo to archive logs"

### DIFF
--- a/jetstream/workflows/run.yaml
+++ b/jetstream/workflows/run.yaml
@@ -4,10 +4,9 @@ metadata:
   generateName: jetstream-
 spec:
   entrypoint: jetstream
-  archiveLogs: true
   ttlStrategy:
     secondsAfterCompletion: 4320000 # delete workflows automatically after 50 days
-    secondsAfterSuccess: 1296000 # delete successful workflows automatically after 15 days
+    secondsAfterSuccess: 432000 # delete successful workflows automatically after 5 days
   arguments:
     parameters:
     - name: experiments  # set dynamically when workflow gets deployed


### PR DESCRIPTION
Reverts mozilla/jetstream#2879

We started seeing pod failures after merging this, with the error:
>Error (exit code 64): You need to configure artifact storage. More information on how to do this can be found in the docs: https://argo-workflows.readthedocs.io/en/latest/configure-artifact-repository/

I am guessing that `archiveLogs` needs a location to store them like GCS. That will require some additional setup (see docs link above) so we'll have to worry about this later.