### PR TITLE
fix: ignore custom enrollments query validation during analysis

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1411,6 +1411,7 @@ class Analysis:
             exposure_signal,
             segments,
             self.config.experiment.sample_size or None,
+            suppress_custom_query_validation=True,
             use_glean_ids=use_glean_ids,
         )
 

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -187,8 +187,9 @@ class ExperimentCollection:
                         NimbusExperiment.from_dict(draft_experiment).to_experiment()
                     )
                 except Exception as e:
-                    print(f"Error converting draft experiment {draft_experiment}")
-                    print(str(e))
+                    logger.exception(
+                        f"Error converting draft experiment {draft_experiment}", exc_info=e
+                    )
 
         return cls(nimbus_experiments + draft_experiments)
 


### PR DESCRIPTION
Should be safe to suppress custom query validation during analysis because it would have already been checked in CI with validate_config. We'll still log a warning here, but it should be reasonable to assume an experiment has only gotten here intentionally.