### PR TITLE
chore: update m-c-p to get configurable analysis units

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -193,7 +193,7 @@ mizani==0.14.3
     # via plotnine
 mozanalysis==2025.10.1
     # via mozilla-jetstream
-mozilla-metric-config-parser==2025.8.1
+mozilla-metric-config-parser==2025.12.1
     # via
     #   mozanalysis
     #   mozilla-jetstream

--- a/requirements.txt
+++ b/requirements.txt
@@ -1155,8 +1155,8 @@ mizani==0.14.3 \
 mozanalysis==2025.10.1 \
     --hash=sha256:eb5b03bf0fb4e7e331f7f5a60c955ade8ea230568414a0ec7fdef598555b24ea
     # via -r requirements.in
-mozilla-metric-config-parser==2025.8.1 \
-    --hash=sha256:659ec7ea9ab039557a821c5d012ab30e55b49608afc1216ecea7fa093bf7df09
+mozilla-metric-config-parser==2025.12.1 \
+    --hash=sha256:0998e40963060928ce96921b8f52d30fb1300c465c04eb0d1d2725d4a416a544
     # via
     #   -r requirements.in
     #   mozanalysis


### PR DESCRIPTION
Latest version of metric-config-parser adds ability to configure analysis_unit, which we want in order to analyze background task message experiments