### PR TITLE
fix: add identity once per segment per branch

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1245,9 +1245,9 @@ class Analysis:
                                 period,
                             ).model_dump(warnings=False)
 
-                            segment_results.root += self.counts(
-                                segment_data, segment, analysis_basis
-                            ).model_dump(warnings=False)
+                        segment_results.root += self.counts(
+                            segment_data, segment, analysis_basis
+                        ).model_dump(warnings=False)
 
                 else:
                     # convert metric configurations to mozanalysis metrics
@@ -1349,9 +1349,9 @@ class Analysis:
                                     period,
                                 ).model_dump(warnings=False)
 
-                                segment_results.root += self.counts(
-                                    segment_data, segment, analysis_basis
-                                ).model_dump(warnings=False)
+                            segment_results.root += self.counts(
+                                segment_data, segment, analysis_basis
+                            ).model_dump(warnings=False)
 
                 # done with analysis_basis: publish metric view
                 results.append(

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -911,6 +911,12 @@ class TestAnalysisIntegration:
             select_expression=agg_sum("active_hours_sum"),
         )
 
+        test_active_hours_2 = Metric(
+            name="active_hours_2",
+            data_source=test_clients_daily,
+            select_expression=agg_sum("active_hours_sum"),
+        )
+
         test_clients_last_seen = SegmentDataSource(
             "clients_last_seen", f"`{project_id}.test_data.clients_last_seen`"
         )
@@ -923,7 +929,12 @@ class TestAnalysisIntegration:
 
         stat = Statistic(name="bootstrap_mean", params={})
 
-        config.metrics = {AnalysisPeriod.WEEK: [Summary(test_active_hours, stat)]}
+        config.metrics = {
+            AnalysisPeriod.WEEK: [
+                Summary(test_active_hours, stat),
+                Summary(test_active_hours_2, stat),
+            ]
+        }
 
         self.analysis_mock_run(
             monkeypatch,


### PR DESCRIPTION
We currently add duplicate results because we're accidentally adding counts redundantly for each Summary instead of just for each segment. This fixes the indentation issue to put the counts call in the correct loop.

I also updated one of the tests to add a second metric so that we can be sure there's only one of the identity counts in the results. This updated test fails without the fix, but passes with the fix.