### PR TITLE
[ci breaking-change] feat: discrete metrics as default

### DIFF
--- a/.github/workflows/detect-possible-breaking-change.yml
+++ b/.github/workflows/detect-possible-breaking-change.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
     - name: Possible Breaking Change Message
       uses: actions/github-script@v8
+      if: ${{ ! startsWith(github.event.pull_request.title, '[ci breaking-change]') }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |          

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -67,6 +67,9 @@ ALL_PERIODS = [
 HIGH_DATA_THRESHOLD = 20
 MODERATE_DATA_THRESHOLD = 10
 
+# Date when discrete metrics was switched to default
+DISCRETE_AS_DEFAULT_THRESHOLD = datetime(2026, 3, 26, tzinfo=pytz.UTC)
+
 
 @attr.s
 class AllType:
@@ -147,7 +150,6 @@ class ArgoExecutorStrategy:
         # then don't pass the --discrete-metrics flag
         # unless --discrete-metrics was passed as an explicit command-line parameter
         client = BigQueryClient(self.project_id, self.dataset_id)
-        DISCRETE_AS_DEFAULT_THRESHOLD = datetime(2026, 3, 26, tzinfo=pytz.UTC)
         discrete_source = click.get_current_context().get_parameter_source("discrete_metrics")
         explicit_discrete = discrete_source == ParameterSource.COMMANDLINE
         discrete_metrics = (
@@ -161,9 +163,11 @@ class ArgoExecutorStrategy:
                     image_version if image_version else artifact_manager.image_for_slug(slug)
                 ),
                 "discrete_metrics": "--no-discrete-metrics"
-                if not explicit_discrete
-                and client.experiment_table_first_updated(slug)
-                and client.experiment_table_first_updated(slug) < DISCRETE_AS_DEFAULT_THRESHOLD
+                if (
+                    not explicit_discrete
+                    and (client.experiment_table_first_updated(slug) or datetime.now(tz=pytz.utc))
+                    <= DISCRETE_AS_DEFAULT_THRESHOLD
+                )
                 else discrete_metrics,
             }
             for slug, dates in experiments_config.items()

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -68,7 +68,7 @@ HIGH_DATA_THRESHOLD = 20
 MODERATE_DATA_THRESHOLD = 10
 
 # Date when discrete metrics was switched to default
-DISCRETE_AS_DEFAULT_THRESHOLD = datetime(2026, 3, 26, tzinfo=pytz.UTC)
+DISCRETE_AS_DEFAULT_THRESHOLD = datetime(2026, 3, 31, tzinfo=pytz.utc)
 
 
 @attr.s

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -14,6 +14,7 @@ import attr
 import click
 import pytz
 import toml
+from click.core import ParameterSource
 from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import bigquery
 from jinja2.exceptions import UndefinedError
@@ -121,22 +122,10 @@ class ArgoExecutorStrategy:
             raise Exception("Custom configurations are not supported when running with Argo")
 
         experiments_config: dict[str, list[str]] = {}
-        # TODO: uncomment this and related lines when adding Argo support for metric_slugs
-        # - this will run each slug in its own argo task, potentially exploding the # of tasks
-        # experiment_metrics_map: dict[str, set[str]] = {}
         for config, date in worklist:
             experiments_config.setdefault(config.experiment.normandy_slug, []).append(
                 date.strftime("%Y-%m-%d")
             )
-            # experiment_metrics_map[config.experiment.normandy_slug] = self.metric_slugs or set()
-            # # if metric_slugs is None or empty list
-            # if not self.metric_slugs:
-            #     # get a set of all metric slugs for the experiment
-            #     for analysis_period, metrics_list in config.metrics.items():
-            #         if analysis_period in self.analysis_periods:
-            #             experiment_metrics_map[config.experiment.normandy_slug].update(
-            #                 {m.metric.name for m in metrics_list}
-            #             )
 
         if self.metric_slugs:
             logger.warning(
@@ -153,6 +142,17 @@ class ArgoExecutorStrategy:
         if self.image_version == "latest":
             image_version = artifact_manager.latest_image()
 
+        # SPECIAL CASE DISCRETE METRICS LOGIC
+        # if the experiment's versioning date is before we flipped to discrete metrics as default
+        # then don't pass the --discrete-metrics flag
+        # unless --discrete-metrics was passed as an explicit command-line parameter
+        client = BigQueryClient(self.project_id, self.dataset_id)
+        DISCRETE_AS_DEFAULT_THRESHOLD = datetime(2026, 3, 26, tzinfo=pytz.UTC)
+        discrete_source = click.get_current_context().get_parameter_source("discrete_metrics")
+        explicit_discrete = discrete_source == ParameterSource.COMMANDLINE
+        discrete_metrics = (
+            "--discrete-metrics" if self.discrete_metrics else "--no-discrete-metrics"
+        )
         experiments_config_list = [
             {
                 "slug": slug,
@@ -160,10 +160,15 @@ class ArgoExecutorStrategy:
                 "image_hash": (
                     image_version if image_version else artifact_manager.image_for_slug(slug)
                 ),
-                # "metric_slugs": list(experiment_metrics_map.get(slug)),
+                "discrete_metrics": "--no-discrete-metrics"
+                if not explicit_discrete
+                and client.experiment_table_first_updated(slug)
+                and client.experiment_table_first_updated(slug) < DISCRETE_AS_DEFAULT_THRESHOLD
+                else discrete_metrics,
             }
             for slug, dates in experiments_config.items()
         ]
+
         logger.info([{cfg["slug"]: cfg["image_hash"]} for cfg in experiments_config_list])
         analysis_period_default = (
             self.analysis_periods[0] if self.analysis_periods != [] else AnalysisPeriod.DAYS_28
@@ -212,9 +217,6 @@ class ArgoExecutorStrategy:
                 ),
                 "image": self.image,
                 "statistics_only": self.statistics_only,
-                "discrete_metrics": "--discrete-metrics"
-                if self.discrete_metrics
-                else "--no-discrete-metrics",
             },
             monitor_status=self.monitor_status,
             cluster_ip=self.cluster_ip,
@@ -820,7 +822,7 @@ discrete_metrics_option = click.option(
     "--discrete_metrics/--no_discrete_metrics",
     is_flag=True,
     help="Whether to split up the metrics query",
-    default=False,
+    default=True,
 )
 
 metric_slugs_option = click.option(

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, Mock
 import attr
 import pytest
 import toml
+from click.core import ParameterSource
+from click.globals import push_context
 from click.testing import CliRunner
 from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.config import Config, ConfigCollection
@@ -619,8 +621,49 @@ class TestSerialExecutorStrategy:
 
 
 class TestArgoExecutorStrategy:
-    @pytest.mark.parametrize("discrete_metrics", [True, False])
-    def test_simple_workflow(self, cli_experiments, monkeypatch, docker_images, discrete_metrics):
+    @pytest.fixture
+    def bq_client_mock(self, request):
+        # dynamically set the experiment date based on the test's parameters
+        # NOTE: depends on current parameters of `test_simple_workflow`
+        experiment_date = dt.datetime(2023, 4, 1, tzinfo=UTC)
+        for k in request.keywords:
+            if "experiment_date" in k:
+                keyword: str = k
+                num = keyword.split("experiment_date")[1][0]
+                if int(num) > 3:
+                    experiment_date = dt.datetime(2026, 4, 1, tzinfo=UTC)
+
+        with mock.patch("jetstream.cli.BigQueryClient") as fixture:
+            bigquery_mock_client = MagicMock()
+            bigquery_mock_client.experiment_table_first_updated.return_value = experiment_date
+            fixture.return_value = bigquery_mock_client
+            yield fixture
+
+    @pytest.mark.parametrize(
+        ("discrete_metrics", "click_param_source", "experiment_date", "expected_discrete"),
+        [
+            # pre-cutoff date defaults to non-discrete
+            (True, ParameterSource.COMMANDLINE, dt.datetime(2023, 4, 1, tzinfo=UTC), True),
+            (True, ParameterSource.DEFAULT, dt.datetime(2023, 4, 1, tzinfo=UTC), False),
+            (False, ParameterSource.COMMANDLINE, dt.datetime(2023, 4, 1, tzinfo=UTC), False),
+            (False, ParameterSource.DEFAULT, dt.datetime(2023, 4, 1, tzinfo=UTC), False),
+            # post-cutoff date defaults to discrete
+            (True, ParameterSource.COMMANDLINE, dt.datetime(2026, 4, 1, tzinfo=UTC), True),
+            (True, ParameterSource.DEFAULT, dt.datetime(2026, 4, 1, tzinfo=UTC), True),
+            (False, ParameterSource.COMMANDLINE, dt.datetime(2026, 4, 1, tzinfo=UTC), False),
+            (False, ParameterSource.DEFAULT, dt.datetime(2026, 4, 1, tzinfo=UTC), False),
+        ],
+    )
+    def test_simple_workflow(
+        self,
+        cli_experiments,
+        monkeypatch,
+        docker_images,
+        discrete_metrics,
+        click_param_source,
+        experiment_date,
+        expected_discrete,
+    ):
         experiment = cli_experiments.experiments[0]
         spec = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs)
         config = spec.resolve(experiment, ConfigLoader.configs)
@@ -628,12 +671,14 @@ class TestArgoExecutorStrategy:
         mock_artifact_client.list_docker_images.return_value = docker_images
         monkeypatch.setattr(ArtifactManager, "client", property(lambda _: mock_artifact_client))
 
+        ctx = MagicMock()
+        ctx.get_parameter_source.return_value = click_param_source
+        push_context(ctx)
+
         with mock.patch("jetstream.cli.submit_workflow") as submit_workflow_mock:
             with mock.patch("jetstream.artifacts.BigQueryClient") as bq_client:
                 bigquery_mock_client = MagicMock()
-                bigquery_mock_client.experiment_table_first_updated.return_value = dt.datetime(
-                    2023, 4, 1, tzinfo=UTC
-                )
+                bigquery_mock_client.experiment_table_first_updated.return_value = experiment_date
                 bq_client.return_value = bigquery_mock_client
 
                 strategy = cli.ArgoExecutorStrategy(
@@ -659,7 +704,7 @@ class TestArgoExecutorStrategy:
                 run_date = dt.datetime(2020, 10, 31, tzinfo=UTC)
                 strategy.execute([(config, run_date)])
 
-            discrete_flag = "--discrete-metrics" if discrete_metrics else "--no-discrete-metrics"
+            discrete_flag = "--discrete-metrics" if expected_discrete else "--no-discrete-metrics"
 
             submit_workflow_mock.assert_called_once_with(
                 project_id="spam",
@@ -672,6 +717,7 @@ class TestArgoExecutorStrategy:
                             "slug": "my_cool_experiment",
                             "dates": ["2020-10-31"],
                             "image_hash": "xxxxx",
+                            "discrete_metrics": discrete_flag,
                         }
                     ],
                     "project_id": "spam",
@@ -685,16 +731,23 @@ class TestArgoExecutorStrategy:
                     "analysis_periods_preenrollment_days28": "preenrollment_days28",
                     "image": "jetstream",
                     "statistics_only": False,
-                    "discrete_metrics": discrete_flag,
                 },
                 monitor_status=False,
                 cluster_ip=None,
                 cluster_cert=None,
             )
 
-    @pytest.mark.parametrize("discrete_metrics", [True, False])
+    @pytest.mark.parametrize(
+        ("discrete_metrics", "click_param_source"),
+        [
+            (True, ParameterSource.COMMANDLINE),
+            (True, ParameterSource.DEFAULT),
+            (False, ParameterSource.COMMANDLINE),
+            (False, ParameterSource.DEFAULT),
+        ],
+    )
     def test_simple_workflow_custom_image(
-        self, bq_client_mock, cli_experiments, monkeypatch, docker_images, discrete_metrics
+        self, cli_experiments, monkeypatch, docker_images, discrete_metrics, click_param_source
     ):
         experiment = cli_experiments.experiments[0]
         spec = AnalysisSpec.default_for_experiment(experiment, ConfigLoader.configs)
@@ -702,6 +755,10 @@ class TestArgoExecutorStrategy:
         mock_artifact_client = Mock()
         mock_artifact_client.list_docker_images.return_value = docker_images
         monkeypatch.setattr(ArtifactManager, "client", property(lambda _: mock_artifact_client))
+
+        ctx = MagicMock()
+        ctx.get_parameter_source.return_value = click_param_source
+        push_context(ctx)
 
         with mock.patch("jetstream.cli.submit_workflow") as submit_workflow_mock:
             strategy = cli.ArgoExecutorStrategy(
@@ -729,7 +786,11 @@ class TestArgoExecutorStrategy:
             run_date = dt.datetime(2020, 10, 31, tzinfo=UTC)
             strategy.execute([(config, run_date)])
 
-            discrete_flag = "--discrete-metrics" if discrete_metrics else "--no-discrete-metrics"
+            discrete_flag = (
+                "--discrete-metrics"
+                if discrete_metrics and click_param_source == ParameterSource.COMMANDLINE
+                else "--no-discrete-metrics"
+            )
 
             submit_workflow_mock.assert_called_once_with(
                 project_id="spam",
@@ -742,6 +803,7 @@ class TestArgoExecutorStrategy:
                             "slug": "my_cool_experiment",
                             "dates": ["2020-10-31"],
                             "image_hash": "aaaaa",
+                            "discrete_metrics": discrete_flag,
                         }
                     ],
                     "project_id": "spam",
@@ -755,7 +817,6 @@ class TestArgoExecutorStrategy:
                     "analysis_periods_preenrollment_days28": "preenrollment_days28",
                     "image": "unrelated",
                     "statistics_only": False,
-                    "discrete_metrics": discrete_flag,
                 },
                 monitor_status=False,
                 cluster_ip=None,

--- a/jetstream/workflows/run.yaml
+++ b/jetstream/workflows/run.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   entrypoint: jetstream
   ttlStrategy:
-    secondsAfterCompletion: 4320000 # delete workflows automatically after 50 days
-    secondsAfterSuccess: 432000 # delete successful workflows automatically after 5 days
+    secondsAfterCompletion: 4320000  # delete workflows automatically after 50 days
+    secondsAfterSuccess: 864000  # delete successful workflows automatically after 10 days
   arguments:
     parameters:
     - name: experiments  # set dynamically when workflow gets deployed
@@ -147,6 +147,7 @@ spec:
         - name: slug
         - name: date
         - name: image_hash
+        - name: discrete_metrics
     steps:
     - - name: analyse-experiment
         template: analyse-experiment  
@@ -158,6 +159,8 @@ spec:
             value: "{{inputs.parameters.date}}"
           - name: image_hash
             value: "{{inputs.parameters.image_hash}}"
+          - name: discrete_metrics
+            value: "{{inputs.parameters.discrete_metrics}}"
     - - name: export-statistics
         template: export-statistics
         arguments:

--- a/jetstream/workflows/run.yaml
+++ b/jetstream/workflows/run.yaml
@@ -37,6 +37,8 @@ spec:
             value: "{{item.dates}}"
           - name: image_hash
             value: "{{item.image_hash}}"
+          - name: discrete_metrics
+            value: "{{item.discrete_metrics}}"
         withParam: "{{inputs.parameters.experiments}}"  # process these experiments in parallel
         continueOn:
           failed: true
@@ -47,6 +49,7 @@ spec:
         - name: image_hash
         - name: slug
         - name: dates
+        - name: discrete_metrics
     steps:
       - - name: ensure-enrollments
           template: ensure-enrollments
@@ -66,6 +69,8 @@ spec:
                 value: "{{item}}"
               - name: image_hash
                 value: "{{inputs.parameters.image_hash}}"
+              - name: discrete_metrics
+                value: "{{inputs.parameters.discrete_metrics}}"
           withParam: "{{inputs.parameters.dates}}"
 
   - name: ensure-enrollments
@@ -88,6 +93,7 @@ spec:
       - name: image_hash
       - name: date
       - name: slug
+      - name: discrete_metrics
     container:
       image: gcr.io/moz-fx-data-experiments/{{workflow.parameters.image}}@sha256:{{inputs.parameters.image_hash}}
       command: [
@@ -104,7 +110,7 @@ spec:
         "--analysis_periods={{workflow.parameters.analysis_periods_preenrollment_week}}",
         "--analysis_periods={{workflow.parameters.analysis_periods_preenrollment_days28}}",
         "--statistics-only={{workflow.parameters.statistics_only}}",
-        "{{workflow.parameters.discrete_metrics}}",
+        "{{inputs.parameters.discrete_metrics}}",
       ]
       resources:
         requests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version = "2026.3.2"
+version = "2026.3.3"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Runs a thing that analyzes experiments"
 readme = "README.md"


### PR DESCRIPTION
- set default value for discrete metrics option as `True`
- use `--no-discrete-metrics` for ongoing experiments
- move the `discrete_metrics` argo parameter to the experiment instead of workflow level (so that it can vary by experiment as needed)

Edited to add:
- don't add warning message if the PR title already starts with `[ci breaking-change]`
- updates tests for the special case discrete logic

Also clarifying that the `DISCRETE_AS_DEFAULT_THRESHOLD` date is set to 2026-03-31 because I will plan to land this on 2026-03-30, which means the first run with discrete-as-default will be on 2026-03-31, and anything computed before that will used non-discrete logic.