### PR TITLE
fix: make ratio metrics work with discrete metrics

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -648,7 +648,7 @@ class Analysis:
                 )
 
         return self._create_subset_metric_table_query_univariate(
-            metric_table_name, segment, summary.metric, analysis_basis, period
+            metric_table_name, segment, summary.metric, analysis_basis, period, discrete_metrics
         )
 
     def _create_subset_metric_table_query_univariate(
@@ -658,6 +658,7 @@ class Analysis:
         metric: Metric,
         analysis_basis: AnalysisBasis,
         period: AnalysisPeriod,
+        discrete_metrics: bool = False,
     ) -> str:
         """Creates a SQL query string to pull a single metric for a segment/analysis"""
 
@@ -672,11 +673,12 @@ class Analysis:
             window = int(metric_table_name.split("_")[-1])
             for dependency in metric.depends_on:
                 metric_names.add(dependency.metric.name)
-                dependency_metric_table = self._table_name(
-                    period.value, window, analysis_basis, dependency.metric.data_source.name
-                )
-                if dependency_metric_table != metric_table_name:
-                    dependency_metric_tables.add(dependency_metric_table)
+                if discrete_metrics:
+                    dependency_metric_table = self._table_name(
+                        period.value, window, analysis_basis, dependency.metric.data_source.name
+                    )
+                    if dependency_metric_table != metric_table_name:
+                        dependency_metric_tables.add(dependency_metric_table)
         else:
             metric_names.add(metric.name)
 

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -611,8 +611,7 @@ class Analysis:
             metric_table_name, segment, summary, analysis_basis, period, discrete_metrics
         )
 
-        logger.debug(f"subset_metric_table: {metric_table_name}, {summary.metric.name}")
-        logger.debug(query)
+        logger.debug(f"subset_metric_table: {metric_table_name}, {summary.metric.name}\n{query}")
 
         results: DataFrame = self.bigquery.execute(query).to_dataframe()
 
@@ -644,11 +643,12 @@ class Analysis:
                     analysis_basis,
                     covariate_period,
                     covariate_metric_name,
+                    period,
                     discrete_metrics,
                 )
 
         return self._create_subset_metric_table_query_univariate(
-            metric_table_name, segment, summary.metric, analysis_basis
+            metric_table_name, segment, summary.metric, analysis_basis, period
         )
 
     def _create_subset_metric_table_query_univariate(
@@ -657,10 +657,11 @@ class Analysis:
         segment: str,
         metric: Metric,
         analysis_basis: AnalysisBasis,
+        period: AnalysisPeriod,
     ) -> str:
         """Creates a SQL query string to pull a single metric for a segment/analysis"""
 
-        metric_names = []
+        metric_names = set()
         # select placeholder column for metrics without select statement
         # since metrics that don't appear in the df are skipped
         # e.g., metrics with depends on such as population ratio metrics
@@ -668,16 +669,16 @@ class Analysis:
         dependency_metric_tables = set()
         if metric.depends_on:
             empty_metric_names.append(f"NULL AS {metric.name}")
+            window = int(metric_table_name.split("_")[-1])
             for dependency in metric.depends_on:
-                metric_names.append(dependency.metric.name)
-                # if the table name doesn't contain metric.name (not discrete metrics), this is noop
-                dependency_metric_table = metric_table_name.replace(
-                    metric.name, dependency.metric.name
+                metric_names.add(dependency.metric.name)
+                dependency_metric_table = self._table_name(
+                    period.value, window, analysis_basis, dependency.metric.data_source.name
                 )
                 if dependency_metric_table != metric_table_name:
                     dependency_metric_tables.add(dependency_metric_table)
         else:
-            metric_names.append(metric.name)
+            metric_names.add(metric.name)
 
         # dependency_joins will be "" if not discrete metrics or no depends_on
         dependency_joins = "\n".join(
@@ -698,17 +699,17 @@ class Analysis:
         )
         query = dedent(
             f"""
-        SELECT branch, {", ".join(metric_names + empty_metric_names)}
-        FROM `{metric_table_name}`
+        SELECT branch, {", ".join(list(metric_names) + empty_metric_names)}
+        FROM `{metric_table_name}` m
         {dependency_joins}
-        WHERE {" IS NOT NULL AND ".join(metric_names + [""])[:-1]}
+        WHERE {" IS NOT NULL AND ".join(list(metric_names) + [""])[:-1]}
         """
         )
 
         if analysis_basis == AnalysisBasis.ENROLLMENTS:
             basis_filter = """enrollment_date IS NOT NULL"""
         elif analysis_basis == AnalysisBasis.EXPOSURES:
-            basis_filter = """enrollment_date IS NOT NULL AND exposure_date IS NOT NULL"""
+            basis_filter = """enrollment_date IS NOT NULL AND m.exposure_date IS NOT NULL"""
         else:
             raise ValueError(
                 f"AnalysisBasis {analysis_basis} not valid"
@@ -734,6 +735,7 @@ class Analysis:
         analysis_basis: AnalysisBasis,
         covariate_period: AnalysisPeriod,
         covariate_metric_name: str,
+        period: AnalysisPeriod,
         discrete_metrics: bool = False,
     ) -> str:
         """Creates a SQL query string to pull a during-experiment metric and join on a
@@ -761,7 +763,7 @@ class Analysis:
                 },
             )
             return self._create_subset_metric_table_query_univariate(
-                metric_table_name, segment, metric, analysis_basis
+                metric_table_name, segment, metric, analysis_basis, period
             )
 
         preenrollment_metric_select = f"pre.{covariate_metric_name} AS {covariate_metric_name}_pre"
@@ -1158,8 +1160,19 @@ class Analysis:
             period_has_metric_slugs = False
 
             for m in self.config.metrics[period]:
-                if (metric_slugs and m.metric.name in metric_slugs) or not metric_slugs:
+                if not metric_slugs:
                     period_has_metric_slugs = True
+                elif metric_slugs and m.metric.name in metric_slugs:
+                    period_has_metric_slugs = True
+                    # for ratio metrics, ensure dependency metrics are not omitted
+                    if m.metric.depends_on:
+                        for summary in m.metric.depends_on:
+                            if summary.metric.name not in metric_slugs:
+                                logger.warning(
+                                    f"`{m.metric.name}` requested without all dependency metrics"
+                                    f" ... Adding `{summary.metric.name}`"
+                                )
+                                metric_slugs.append(summary.metric.name)
 
                 for analysis_basis in m.metric.analysis_bases:
                     analysis_bases.append(analysis_basis)
@@ -1174,6 +1187,13 @@ class Analysis:
 
             if len(analysis_bases) == 0:
                 continue
+
+            segment_labels = ["all"] + [s.name for s in self.config.experiment.segments]
+            analysis_length_dates = 1
+            if period.value == AnalysisPeriod.OVERALL:
+                analysis_length_dates = time_limits.analysis_length_dates
+            elif period.value == AnalysisPeriod.WEEK:
+                analysis_length_dates = 7
 
             for analysis_basis in analysis_bases:
                 segment_data: DataFrame
@@ -1218,7 +1238,6 @@ class Analysis:
                             )
                             continue
 
-                    segment_labels = ["all"] + [s.name for s in self.config.experiment.segments]
                     for segment in segment_labels:
                         for summary in self.config.metrics[period]:
                             if (
@@ -1235,12 +1254,6 @@ class Analysis:
                                 period,
                                 False,
                             )
-
-                            analysis_length_dates = 1
-                            if period.value == AnalysisPeriod.OVERALL:
-                                analysis_length_dates = time_limits.analysis_length_dates
-                            elif period.value == AnalysisPeriod.WEEK:
-                                analysis_length_dates = 7
 
                             segment_results.root += self.calculate_statistics(
                                 summary,
@@ -1264,18 +1277,21 @@ class Analysis:
                             m.metric.analysis_bases == analysis_basis
                             or analysis_basis in m.metric.analysis_bases
                         )
-                        and m.metric.select_expression is not None
+                        and (metric_slugs is None or m.metric.name in metric_slugs)
                     ]
+                    # metrics with depends_on have no select_expression and are handled separately
                     config_metrics: set[Metric] = (
                         {
                             Metric.from_metric_config(m.metric).to_mozanalysis_metric()
                             for m in summary_metrics
                             if m.metric.name in metric_slugs
+                            and m.metric.select_expression is not None
                         }
                         if metric_slugs
                         else {
                             Metric.from_metric_config(m.metric).to_mozanalysis_metric()
                             for m in summary_metrics
+                            if m.metric.select_expression is not None
                         }
                     )
 
@@ -1337,7 +1353,6 @@ class Analysis:
                                     )
                                 continue
 
-                        segment_labels = ["all"] + [s.name for s in self.config.experiment.segments]
                         for segment in segment_labels:
                             for summary in summary_metrics:
                                 if not (
@@ -1356,12 +1371,6 @@ class Analysis:
                                     True,
                                 )
 
-                                analysis_length_dates = 1
-                                if period.value == AnalysisPeriod.OVERALL:
-                                    analysis_length_dates = time_limits.analysis_length_dates
-                                elif period.value == AnalysisPeriod.WEEK:
-                                    analysis_length_dates = 7
-
                                 segment_results.root += self.calculate_statistics(
                                     summary,
                                     segment_data,
@@ -1373,6 +1382,30 @@ class Analysis:
 
                             segment_results.root += self.counts(
                                 segment_data, segment, analysis_basis
+                            ).model_dump(warnings=False)
+
+                    # metrics are done: now iterate over the depends_on metrics
+                    for summary in summary_metrics:
+                        if not summary.metric.depends_on:
+                            continue
+
+                        for segment in segment_labels:
+                            segment_data = self.subset_metric_table(
+                                metric_table,
+                                segment,
+                                summary,
+                                analysis_basis,
+                                period,
+                                True,
+                            )
+
+                            segment_results.root += self.calculate_statistics(
+                                summary,
+                                segment_data,
+                                segment,
+                                analysis_basis,
+                                analysis_length_dates,
+                                period,
                             ).model_dump(warnings=False)
 
                 # done with analysis_basis: publish metric view

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -902,7 +902,7 @@ def run(
             ctx.obj["log_config"],
             analysis_periods=analysis_periods,
             sql_output_dir=sql_output_dir,
-            metric_slugs=metric_slug if metric_slug else None,
+            metric_slugs=list(metric_slug) if metric_slug else None,
             statistics_only=statistics_only,
             use_glean_ids=use_glean_ids,
             discrete_metrics=discrete_metrics,
@@ -979,7 +979,7 @@ def run_argo(
         image_version=image_version,
         statistics_only=statistics_only,
         discrete_metrics=discrete_metrics,
-        metric_slugs=metric_slug if metric_slug else None,
+        metric_slugs=list(metric_slug) if metric_slug else None,
     )
 
     AnalysisExecutor(
@@ -1066,7 +1066,7 @@ def rerun(
         analysis_periods=analysis_periods,
         statistics_only=statistics_only,
         discrete_metrics=discrete_metrics,
-        metric_slugs=metric_slug if metric_slug else None,
+        metric_slugs=list(metric_slug) if metric_slug else None,
     )
 
     if argo:
@@ -1086,7 +1086,7 @@ def rerun(
             image_version=image_version,
             statistics_only=statistics_only,
             discrete_metrics=discrete_metrics,
-            metric_slugs=metric_slug if metric_slug else None,
+            metric_slugs=list(metric_slug) if metric_slug else None,
         )
 
     success = AnalysisExecutor(

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -616,6 +616,7 @@ class TestAnalysisIntegration:
             is not None
         )
 
+    @pytest.mark.parametrize("discrete_metrics", [True, False])
     def test_metrics_with_depends_on(
         self,
         monkeypatch,
@@ -625,6 +626,7 @@ class TestAnalysisIntegration:
         temporary_dataset,
         randomization_unit,
         analysis_unit,
+        discrete_metrics,
     ):
         experiment = Experiment(
             experimenter_slug="test-experiment",
@@ -704,13 +706,20 @@ class TestAnalysisIntegration:
             static_dataset,
             temporary_dataset,
             project_id,
+            discrete_metrics=discrete_metrics,
+        )
+
+        table_id = (
+            "test_experiment_enrollments_clients_daily_week_1"
+            if discrete_metrics
+            else "test_experiment_enrollments_week_1"
         )
 
         query_job = client.client.query(
             f"""
             SELECT
               *
-            FROM `{project_id}.{temporary_dataset}.test_experiment_enrollments_week_1`
+            FROM `{project_id}.{temporary_dataset}.{table_id}`
             ORDER BY enrollment_date DESC
         """
         )

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -328,7 +328,11 @@ def test_create_subset_metric_table_query_univariate_basic(experiments):
     )
 
     actual_query = _empty_analysis(experiments)._create_subset_metric_table_query_univariate(
-        "test_experiment_enrollments_1", "all", metric, AnalysisBasis.ENROLLMENTS
+        "test_experiment_enrollments_1",
+        "all",
+        metric,
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
@@ -396,6 +400,7 @@ def test_create_subset_metric_table_query_covariate_basic(randomization_unit, mo
         AnalysisBasis.ENROLLMENTS,
         AnalysisPeriod.PREENROLLMENT_WEEK,
         "metric_name",
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
@@ -435,6 +440,7 @@ def test_create_subset_metric_table_query_covariate_missing_table_fallback(
         AnalysisBasis.ENROLLMENTS,
         AnalysisPeriod.PREENROLLMENT_WEEK,
         "metric_name",
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
@@ -465,7 +471,11 @@ def test_create_subset_metric_table_query_univariate_segment(experiments):
     )
 
     actual_query = _empty_analysis(experiments)._create_subset_metric_table_query_univariate(
-        "test_experiment_enrollments_1", "mysegment", metric, AnalysisBasis.ENROLLMENTS
+        "test_experiment_enrollments_1",
+        "mysegment",
+        metric,
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
@@ -534,6 +544,7 @@ def test_create_subset_metric_table_query_covariate_segment(randomization_unit, 
         AnalysisBasis.ENROLLMENTS,
         AnalysisPeriod.PREENROLLMENT_WEEK,
         "metric_name",
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
@@ -553,11 +564,15 @@ def test_create_subset_metric_table_query_univariate_exposures(experiments):
     FROM `test_experiment_exposures_1` m
 
     WHERE metric_name IS NOT NULL AND
-    enrollment_date IS NOT NULL AND exposure_date IS NOT NULL"""
+    enrollment_date IS NOT NULL AND m.exposure_date IS NOT NULL"""
     )
 
     actual_query = _empty_analysis(experiments)._create_subset_metric_table_query_univariate(
-        "test_experiment_exposures_1", "all", metric, AnalysisBasis.EXPOSURES
+        "test_experiment_exposures_1",
+        "all",
+        metric,
+        AnalysisBasis.EXPOSURES,
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
@@ -625,15 +640,29 @@ def test_create_subset_metric_table_query_covariate_exposures(randomization_unit
         AnalysisBasis.EXPOSURES,
         AnalysisPeriod.PREENROLLMENT_WEEK,
         "metric_name",
+        AnalysisPeriod.WEEK,
     )
 
     assert expected_query == actual_query
 
 
-def test_create_subset_metric_table_query_univariate_depends_on(experiments):
+def test_create_subset_metric_table_query_univariate_depends_on(experiments, monkeypatch):
+    # Return different dependency table names based on the data source argument (args[3])
+    # so that both upstream metrics produce distinct LEFT JOINs.
+    def table_name_side_effect(*args, **kwargs):
+        data_source = args[3] if len(args) > 3 else kwargs.get("metric")
+        if data_source == "data_source_a":
+            return "dep_table_a_1"
+        return "dep_table_b_1"
+
+    monkeypatch.setattr(
+        "jetstream.analysis.Analysis._table_name",
+        MagicMock(side_effect=table_name_side_effect),
+    )
+
     upstream_1_metric = Metric(
         name="upstream_1",
-        data_source=DataSource(name="test_data_source", from_expression="test.test"),
+        data_source=DataSource(name="data_source_a", from_expression="test.test"),
         select_expression="test",
         analysis_bases=[AnalysisBasis.ENROLLMENTS],
     )
@@ -641,35 +670,35 @@ def test_create_subset_metric_table_query_univariate_depends_on(experiments):
 
     upstream_2_metric = Metric(
         name="upstream_2",
-        data_source=DataSource(name="test_data_source", from_expression="test.test"),
+        data_source=DataSource(name="data_source_b", from_expression="test.test"),
         select_expression="test",
         analysis_bases=[AnalysisBasis.ENROLLMENTS],
     )
-
     upstream_2 = Summary(upstream_2_metric, None, None)
 
     metric = Metric(
-        name="metric_name",
+        name="ratio_metric",
         data_source=DataSource(name="test_data_source", from_expression="test.test"),
-        select_expression="test",
+        select_expression=None,
         analysis_bases=[AnalysisBasis.ENROLLMENTS],
         depends_on=[upstream_1, upstream_2],
     )
 
-    expected_query = dedent(
-        """
-    SELECT branch, upstream_1, upstream_2, NULL AS metric_name
-    FROM `test_experiment_enrollments_1` m
-
-    WHERE upstream_1 IS NOT NULL AND upstream_2 IS NOT NULL AND
-    enrollment_date IS NOT NULL"""
-    )
-
     actual_query = _empty_analysis(experiments)._create_subset_metric_table_query_univariate(
-        "test_experiment_enrollments_1", "all", metric, AnalysisBasis.ENROLLMENTS
+        "dep_table_a_1", "all", metric, AnalysisBasis.ENROLLMENTS, AnalysisPeriod.DAY
     )
 
-    assert expected_query == actual_query
+    # can't assert whole query because order of metrics is not guaranteed
+    assert "upstream_1" in actual_query
+    assert "upstream_2" in actual_query
+    assert "NULL AS ratio_metric" in actual_query
+    assert "FROM `dep_table_a_1` m" in actual_query
+    assert "LEFT JOIN `dep_table_b_1`" in actual_query
+    assert "analysis_id" in actual_query
+    assert "analysis_window_start" in actual_query
+    assert "enrollment_date IS NOT NULL" in actual_query
+
+    assert "LEFT JOIN `dep_table_a_1`" not in actual_query
 
 
 def test_create_subset_metric_table_query_covariate_depends_on(experiments, monkeypatch):
@@ -712,6 +741,7 @@ def test_create_subset_metric_table_query_covariate_depends_on(experiments, monk
             AnalysisBasis.ENROLLMENTS,
             AnalysisPeriod.PREENROLLMENT_WEEK,
             "metric_name",
+            AnalysisPeriod.WEEK,
         )
 
 
@@ -731,7 +761,11 @@ def test_create_subset_metric_table_query_univariate_unsupported_analysis_basis(
     )
     with pytest.raises(ValueError, match=re.escape(error_str)):
         _empty_analysis(experiments)._create_subset_metric_table_query_univariate(
-            "test_experiment_exposures_1", "all", metric, analysis_basis
+            "test_experiment_exposures_1",
+            "all",
+            metric,
+            analysis_basis,
+            AnalysisPeriod.WEEK,
         )
 
 
@@ -761,6 +795,7 @@ def test_create_subset_metric_table_query_covariate_unsupported_analysis_basis(
             analysis_basis,
             AnalysisPeriod.PREENROLLMENT_WEEK,
             "metric_name",
+            AnalysisPeriod.WEEK,
         )
 
 
@@ -1139,3 +1174,55 @@ def test_create_subset_metric_table_query_complete_univariate(experiments):
     )
 
     assert expected_query == actual_query
+
+
+def test_metric_slugs_adds_depends_on_metrics(experiments, monkeypatch):
+    config = AnalysisSpec.default_for_experiment(experiments[0], ConfigLoader.configs).resolve(
+        experiments[0], ConfigLoader.configs
+    )
+
+    upstream_1_metric = Metric(
+        name="upstream_1",
+        data_source=DataSource(name="test_data_source", from_expression="test.test"),
+        select_expression="test",
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+    )
+    upstream_2_metric = Metric(
+        name="upstream_2",
+        data_source=DataSource(name="test_data_source", from_expression="test.test"),
+        select_expression="test",
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+    )
+    ratio_metric = Metric(
+        name="ratio_metric",
+        data_source=DataSource(name="test_data_source", from_expression="test.test"),
+        select_expression=None,
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+        depends_on=[
+            Summary(upstream_1_metric, None, None),
+            Summary(upstream_2_metric, None, None),
+        ],
+    )
+    config.metrics[AnalysisPeriod.WEEK].append(Summary(ratio_metric, MagicMock(), []))
+
+    monkeypatch.setattr("jetstream.analysis.Analysis.ensure_enrollments", Mock())
+    monkeypatch.setattr(
+        "jetstream.analysis.Analysis._get_timelimits_if_ready", MagicMock(return_value=MagicMock())
+    )
+    monkeypatch.setattr("jetstream.analysis.Analysis.calculate_metrics", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.Analysis.save_statistics", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.Analysis.publish_view", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.bind", lambda x, deps: x)
+    monkeypatch.setattr("jetstream.analysis.LocalCluster", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.Client", MagicMock())
+
+    metric_slugs = ["ratio_metric"]
+    Analysis("test", "test", config).run(
+        current_date=dt.datetime(2020, 1, 1, tzinfo=pytz.utc),
+        dry_run=True,
+        metric_slugs=metric_slugs,
+    )
+
+    assert "upstream_1" in metric_slugs
+    assert "upstream_2" in metric_slugs
+    assert "ratio_metric" in metric_slugs

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -321,7 +321,7 @@ def test_create_subset_metric_table_query_univariate_basic(experiments):
     expected_query = dedent(
         """
     SELECT branch, metric_name
-    FROM `test_experiment_enrollments_1`
+    FROM `test_experiment_enrollments_1` m
 
     WHERE metric_name IS NOT NULL AND
     enrollment_date IS NOT NULL"""
@@ -422,7 +422,7 @@ def test_create_subset_metric_table_query_covariate_missing_table_fallback(
     expected_query = dedent(
         """
     SELECT branch, metric_name
-    FROM `test_experiment_enrollments_1`
+    FROM `test_experiment_enrollments_1` m
 
     WHERE metric_name IS NOT NULL AND
     enrollment_date IS NOT NULL"""
@@ -457,7 +457,7 @@ def test_create_subset_metric_table_query_univariate_segment(experiments):
     expected_query = dedent(
         """
     SELECT branch, metric_name
-    FROM `test_experiment_enrollments_1`
+    FROM `test_experiment_enrollments_1` m
 
     WHERE metric_name IS NOT NULL AND
     enrollment_date IS NOT NULL
@@ -550,7 +550,7 @@ def test_create_subset_metric_table_query_univariate_exposures(experiments):
     expected_query = dedent(
         """
     SELECT branch, metric_name
-    FROM `test_experiment_exposures_1`
+    FROM `test_experiment_exposures_1` m
 
     WHERE metric_name IS NOT NULL AND
     enrollment_date IS NOT NULL AND exposure_date IS NOT NULL"""
@@ -659,7 +659,7 @@ def test_create_subset_metric_table_query_univariate_depends_on(experiments):
     expected_query = dedent(
         """
     SELECT branch, upstream_1, upstream_2, NULL AS metric_name
-    FROM `test_experiment_enrollments_1`
+    FROM `test_experiment_enrollments_1` m
 
     WHERE upstream_1 IS NOT NULL AND upstream_2 IS NOT NULL AND
     enrollment_date IS NOT NULL"""
@@ -1068,7 +1068,7 @@ def test_create_subset_metric_table_query_covariate_fallback(randomization_unit,
     expected_query = dedent(
         """
     SELECT branch, metric_name
-    FROM `test_experiment_enrollments_1`
+    FROM `test_experiment_enrollments_1` m
 
     WHERE metric_name IS NOT NULL AND
     enrollment_date IS NOT NULL"""
@@ -1124,7 +1124,7 @@ def test_create_subset_metric_table_query_complete_univariate(experiments):
     expected_query = dedent(
         """
     SELECT branch, metric_name
-    FROM `test_experiment_enrollments_1`
+    FROM `test_experiment_enrollments_1` m
 
     WHERE metric_name IS NOT NULL AND
     enrollment_date IS NOT NULL"""

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -685,7 +685,12 @@ def test_create_subset_metric_table_query_univariate_depends_on(experiments, mon
     )
 
     actual_query = _empty_analysis(experiments)._create_subset_metric_table_query_univariate(
-        "dep_table_a_1", "all", metric, AnalysisBasis.ENROLLMENTS, AnalysisPeriod.DAY
+        "dep_table_a_1",
+        "all",
+        metric,
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.DAY,
+        discrete_metrics=True,
     )
 
     # can't assert whole query because order of metrics is not guaranteed


### PR DESCRIPTION
Ratio/depends_on metrics weren't working with discrete metrics because of a few issues:
- these metrics were being filtered out when we ensured `select_expression` was defined
- the subset metric table query had a bug with the data source groupings

While I was in there, I also noticed that there could be issues with these metrics when using `--metric-slug`, so I added a fix to ensure that the `depends_on` metrics are in the `metric_slugs` list if needed.

fixes #3122 