### PR TITLE
feat: incorporate configured enrollments_query_type

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -919,7 +919,8 @@ class Analysis:
 
         enrollments_sql = exp.build_enrollments_query(
             limits,
-            PLATFORM_CONFIGS[self.config.experiment.app_name].enrollments_query_type,
+            self.config.experiment.enrollments_query_type
+            or PLATFORM_CONFIGS[self.config.experiment.app_name].enrollments_query_type,
             self.config.experiment.enrollment_query,
             None,
             exposure_signal,
@@ -1463,7 +1464,8 @@ class Analysis:
 
         return exp.build_enrollments_query(
             time_limits,
-            PLATFORM_CONFIGS[self.config.experiment.app_name].enrollments_query_type,
+            self.config.experiment.enrollments_query_type
+            or PLATFORM_CONFIGS[self.config.experiment.app_name].enrollments_query_type,
             self.config.experiment.enrollment_query,
             None,
             exposure_signal,

--- a/jetstream/platform.py
+++ b/jetstream/platform.py
@@ -5,7 +5,7 @@ from typing import Any
 import attr
 import toml
 from metric_config_parser.analysis import AnalysisSpec
-from mozanalysis.experiment import EnrollmentsQueryType
+from metric_config_parser.experiment import EnrollmentsQueryType
 
 from jetstream.config import ConfigLoader
 
@@ -27,7 +27,7 @@ class Platform:
     More info about Jetstream configuration: https://experimenter.info/jetstream/configuration
 
     :param enrollments_query_type:
-    :type enrollments_query_type: mozanalysis.experiment.EnrollmentsQueryType
+    :type enrollments_query_type: metric_config_parser.experiment.EnrollmentsQueryType
     :param app_id:
     :type app_id: str
 

--- a/jetstream/preview.py
+++ b/jetstream/preview.py
@@ -4,9 +4,9 @@ import mozanalysis
 from metric_config_parser import AnalysisUnit
 from metric_config_parser.analysis import AnalysisConfiguration
 from metric_config_parser.data_source import DataSourceReference
+from metric_config_parser.experiment import EnrollmentsQueryType
 from metric_config_parser.exposure_signal import ExposureSignalDefinition
 from metric_config_parser.metric import AnalysisPeriod
-from mozanalysis.experiment import EnrollmentsQueryType
 
 from .analysis import Analysis
 from .platform import PLATFORM_CONFIGS

--- a/jetstream/tests/test_config.py
+++ b/jetstream/tests/test_config.py
@@ -5,8 +5,8 @@ import pytest
 import toml
 from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.config import Config, DefaultConfig, Outcome
+from metric_config_parser.experiment import EnrollmentsQueryType
 from metric_config_parser.outcome import OutcomeSpec
-from mozanalysis.experiment import EnrollmentsQueryType
 
 from jetstream.config import ConfigLoader, _ConfigLoader, validate
 from jetstream.dryrun import DryRunFailedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version = "2026.3.3"
+version = "2026.4.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Runs a thing that analyzes experiments"
 readme = "README.md"

--- a/requirements.in
+++ b/requirements.in
@@ -188,9 +188,9 @@ matplotlib==3.10.8
     #   plotnine
 mizani==0.14.4
     # via plotnine
-mozanalysis==2026.1.2
+mozanalysis==2026.4.1
     # via mozilla-jetstream
-mozilla-metric-config-parser==2026.1.1
+mozilla-metric-config-parser==2026.4.1
     # via
     #   mozanalysis
     #   mozilla-jetstream

--- a/requirements.txt
+++ b/requirements.txt
@@ -1281,11 +1281,11 @@ mizani==0.14.4 \
     # via
     #   -r requirements.in
     #   plotnine
-mozanalysis==2026.1.2 \
-    --hash=sha256:fa2471e24f4d952bb257423912eef8094a067c314efa629fc69f52a34c9c9b5d
+mozanalysis==2026.4.1 \
+    --hash=sha256:642b479ad6191dc0980de0a16062c02c67495ad654ceea012342cb52f23319d2
     # via -r requirements.in
-mozilla-metric-config-parser==2026.1.1 \
-    --hash=sha256:0e74d8a453a839cd5eb82799655ddc1d2c79c461ce099375749c23b6ffdb4903
+mozilla-metric-config-parser==2026.4.1 \
+    --hash=sha256:b349016cae82b59427b69f800f162a77ce80dc82693ef2a8718675e1b6198e90
     # via
     #   -r requirements.in
     #   mozanalysis


### PR DESCRIPTION
Prefer the configured value for `enrollments_query_type` if it exists, otherwise use the PLATFORM_CONFIG.

Follow up to https://github.com/mozilla/metric-hub/pull/1392 and https://github.com/mozilla/mozanalysis/pull/534