### PR TITLE
fix: explicit dependency chain for metric - statistic

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -821,20 +821,20 @@ class Analysis:
         analysis_basis: AnalysisBasis,
         period: AnalysisPeriod,
         discrete_metrics: bool,
-    ) -> list[str]:
+    ) -> set[str]:
         """Returns the BigQuery table names referenced by a subset_metric_table query
         that are NOT already covered by the metric_table_name positional arg.
 
         Used to build explicit Dask ordering edges so readers never run before their
         writers, regardless of parallel-scheduler ordering.
         """
-        prereqs: list[str] = []
+        prereqs: set[str] = set()
 
         if covariate_params := summary.statistic.params.get("covariate_adjustment", False):  # type: ignore[attr-defined]
             covariate_period = AnalysisPeriod(covariate_params["period"])
             if covariate_period != period and period not in PREENROLLMENT_PERIODS:
                 metric_name = summary.metric.name if discrete_metrics else None
-                prereqs.append(
+                prereqs.add(
                     self._table_name(
                         covariate_period.value, 1, AnalysisBasis.ENROLLMENTS, metric=metric_name
                     )
@@ -846,8 +846,8 @@ class Analysis:
                 dep_table = self._table_name(
                     period.value, window, analysis_basis, dependency.metric.data_source.name
                 )
-                if dep_table != metric_table_name and dep_table not in prereqs:
-                    prereqs.append(dep_table)
+                if dep_table != metric_table_name:
+                    prereqs.add(dep_table)
 
         return prereqs
 

--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from multiprocessing import Pool
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import attr
 import dask
@@ -44,6 +44,9 @@ from jetstream.statistics import (
 )
 
 from . import bq_normalize_name
+
+if TYPE_CHECKING:
+    from dask.delayed import Delayed
 
 logger = logging.getLogger(__name__)
 
@@ -811,6 +814,43 @@ class Analysis:
 
         return query
 
+    def _subset_metric_table_prerequisites(
+        self,
+        summary: Summary,
+        metric_table_name: str,
+        analysis_basis: AnalysisBasis,
+        period: AnalysisPeriod,
+        discrete_metrics: bool,
+    ) -> list[str]:
+        """Returns the BigQuery table names referenced by a subset_metric_table query
+        that are NOT already covered by the metric_table_name positional arg.
+
+        Used to build explicit Dask ordering edges so readers never run before their
+        writers, regardless of parallel-scheduler ordering.
+        """
+        prereqs: list[str] = []
+
+        if covariate_params := summary.statistic.params.get("covariate_adjustment", False):  # type: ignore[attr-defined]
+            covariate_period = AnalysisPeriod(covariate_params["period"])
+            if covariate_period != period and period not in PREENROLLMENT_PERIODS:
+                metric_name = summary.metric.name if discrete_metrics else None
+                prereqs.append(
+                    self._table_name(
+                        covariate_period.value, 1, AnalysisBasis.ENROLLMENTS, metric=metric_name
+                    )
+                )
+
+        if discrete_metrics and summary.metric.depends_on:
+            window = int(metric_table_name.split("_")[-1])
+            for dependency in summary.metric.depends_on:
+                dep_table = self._table_name(
+                    period.value, window, analysis_basis, dependency.metric.data_source.name
+                )
+                if dep_table != metric_table_name and dep_table not in prereqs:
+                    prereqs.append(dep_table)
+
+        return prereqs
+
     def check_runnable(self, current_date: datetime | None = None) -> bool:
         if self.config.experiment.normandy_slug is None:
             # some experiments do not have a normandy slug
@@ -1105,6 +1145,7 @@ class Analysis:
         client = Client(_dask_cluster)
 
         results = []
+        metric_table_writers: dict[str, Delayed] = {}
 
         if self.log_config:
             log_plugin = LogPlugin(self.log_config)
@@ -1213,6 +1254,14 @@ class Analysis:
                         metric_slugs=metric_slugs,
                     )
                     metrics_results.append(metrics_table)
+                    # calculate_metrics returns a Delayed — compute the table name eagerly so we
+                    # can register it for Dask dependency wiring before any readers are created.
+                    metrics_table_name = self._table_name(
+                        period.value,
+                        len(time_limits.analysis_windows),
+                        analysis_basis=analysis_basis,
+                    )
+                    metric_table_writers[metrics_table_name] = metrics_table
 
                     if dry_run:
                         results.append(metrics_table)
@@ -1224,22 +1273,16 @@ class Analysis:
                         )
                         continue
 
-                    if statistics_only:
-                        metrics_table_name = self._table_name(
-                            period.value,
-                            len(time_limits.analysis_windows),
-                            analysis_basis=analysis_basis,
+                    if statistics_only and not self.bigquery.table_exists(metrics_table_name):
+                        logger.warning(
+                            f"Cannot compute only statistics for period {period.value}; "
+                            "metric table does not exist!",
+                            extra={
+                                "experiment": self.config.experiment.normandy_slug,
+                                "analysis_basis": analysis_basis.value,
+                            },
                         )
-                        if not self.bigquery.table_exists(metrics_table_name):
-                            logger.warning(
-                                f"Cannot compute only statistics for period {period.value}; "
-                                "metric table does not exist!",
-                                extra={
-                                    "experiment": self.config.experiment.normandy_slug,
-                                    "analysis_basis": analysis_basis.value,
-                                },
-                            )
-                            continue
+                        continue
 
                     for segment in segment_labels:
                         for summary in self.config.metrics[period]:
@@ -1249,13 +1292,24 @@ class Analysis:
                             ):
                                 continue
 
-                            segment_data = self.subset_metric_table(
+                            prereq_tables = self._subset_metric_table_prerequisites(
+                                summary, metrics_table_name, analysis_basis, period, False
+                            )
+                            prereqs = [
+                                metric_table_writers[t]
+                                for t in prereq_tables
+                                if t in metric_table_writers
+                            ]
+                            subset_delayed = self.subset_metric_table(
                                 metrics_table,
                                 segment,
                                 summary,
                                 analysis_basis,
                                 period,
                                 False,
+                            )
+                            segment_data = (
+                                bind(subset_delayed, prereqs) if prereqs else subset_delayed
                             )
 
                             segment_results.root += self.calculate_statistics(
@@ -1313,6 +1367,15 @@ class Analysis:
                             dry_run or statistics_only,
                         )
                         metrics_results.append(metric_table)
+                        # calculate_metric_for_ds returns a Delayed — compute the table name eagerly
+                        # so we can register it as a Dask dep before trying to read from it.
+                        metric_table_name = self._table_name(
+                            period.value,
+                            len(time_limits.analysis_windows),
+                            analysis_basis=analysis_basis,
+                            metric=data_source.name,
+                        )
+                        metric_table_writers[metric_table_name] = metric_table
 
                         # get sanity metrics for this data source (to include in view)
                         all_metrics_by_ds[data_source.name] = [
@@ -1335,26 +1398,19 @@ class Analysis:
                             )
                             continue
 
-                        if statistics_only:
-                            metric_table_name = self._table_name(
-                                period.value,
-                                len(time_limits.analysis_windows),
-                                analysis_basis=analysis_basis,
-                                metric=data_source.name,
-                            )
-                            if not self.bigquery.table_exists(metric_table_name):
-                                for metric in data_source:
-                                    logger.warning(
-                                        f"Cannot compute only statistics for period {period.value};"
-                                        "metrics table doesn't exist"
-                                        f"for data source {data_source.name}!",
-                                        extra={
-                                            "experiment": self.config.experiment.normandy_slug,
-                                            "metric": metric.name,
-                                            "analysis_basis": analysis_basis.value,
-                                        },
-                                    )
-                                continue
+                        if statistics_only and not self.bigquery.table_exists(metric_table_name):
+                            for metric in data_source:
+                                logger.warning(
+                                    f"Cannot compute only statistics for period {period.value};"
+                                    "metrics table doesn't exist"
+                                    f"for data source {data_source.name}!",
+                                    extra={
+                                        "experiment": self.config.experiment.normandy_slug,
+                                        "metric": metric.name,
+                                        "analysis_basis": analysis_basis.value,
+                                    },
+                                )
+                            continue
 
                         for segment in segment_labels:
                             for summary in summary_metrics:
@@ -1365,13 +1421,24 @@ class Analysis:
                                     # metric not part of current data source
                                     continue
 
-                                segment_data = self.subset_metric_table(
+                                prereq_tables = self._subset_metric_table_prerequisites(
+                                    summary, metric_table_name, analysis_basis, period, True
+                                )
+                                prereqs = [
+                                    metric_table_writers[t]
+                                    for t in prereq_tables
+                                    if t in metric_table_writers
+                                ]
+                                subset_delayed = self.subset_metric_table(
                                     metric_table,
                                     segment,
                                     summary,
                                     analysis_basis,
                                     period,
                                     True,
+                                )
+                                segment_data = (
+                                    bind(subset_delayed, prereqs) if prereqs else subset_delayed
                                 )
 
                                 segment_results.root += self.calculate_statistics(
@@ -1392,14 +1459,25 @@ class Analysis:
                         if not summary.metric.depends_on:
                             continue
 
+                        prereq_tables = self._subset_metric_table_prerequisites(
+                            summary, metric_table_name, analysis_basis, period, True
+                        )
+                        prereqs = [
+                            metric_table_writers[t]
+                            for t in prereq_tables
+                            if t in metric_table_writers
+                        ]
                         for segment in segment_labels:
-                            segment_data = self.subset_metric_table(
+                            subset_delayed = self.subset_metric_table(
                                 metric_table,
                                 segment,
                                 summary,
                                 analysis_basis,
                                 period,
                                 True,
+                            )
+                            segment_data = (
+                                bind(subset_delayed, prereqs) if prereqs else subset_delayed
                             )
 
                             segment_results.root += self.calculate_statistics(

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -1247,7 +1247,7 @@ def test_subset_metric_table_prerequisites_simple(experiments):
         False,
     )
 
-    assert prereqs == []
+    assert prereqs == set()
 
 
 def test_subset_metric_table_prerequisites_covariate(experiments):
@@ -1270,7 +1270,7 @@ def test_subset_metric_table_prerequisites_covariate(experiments):
     expected_covariate_table = analysis._table_name(
         AnalysisPeriod.PREENROLLMENT_WEEK.value, 1, AnalysisBasis.ENROLLMENTS
     )
-    assert prereqs == [expected_covariate_table]
+    assert prereqs == {expected_covariate_table}
 
 
 def test_subset_metric_table_prerequisites_covariate_skipped_for_preenrollment_period(experiments):
@@ -1290,7 +1290,7 @@ def test_subset_metric_table_prerequisites_covariate_skipped_for_preenrollment_p
         False,
     )
 
-    assert prereqs == []
+    assert prereqs == set()
 
 
 def test_subset_metric_table_prerequisites_discrete_depends_on(experiments):

--- a/jetstream/tests/test_analysis.py
+++ b/jetstream/tests/test_analysis.py
@@ -1231,3 +1231,179 @@ def test_metric_slugs_adds_depends_on_metrics(experiments, monkeypatch):
     assert "upstream_1" in metric_slugs
     assert "upstream_2" in metric_slugs
     assert "ratio_metric" in metric_slugs
+
+
+def test_subset_metric_table_prerequisites_simple(experiments):
+    """A plain metric with no covariate and no depends_on has no additional prerequisites."""
+    summary = MagicMock()
+    summary.statistic.params = {}
+    summary.metric.depends_on = None
+
+    prereqs = _empty_analysis(experiments)._subset_metric_table_prerequisites(
+        summary,
+        "normandy_test_slug_enrollments_week_1",
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.WEEK,
+        False,
+    )
+
+    assert prereqs == []
+
+
+def test_subset_metric_table_prerequisites_covariate(experiments):
+    """Covariate adjustment against preenrollment_week returns the covariate table name."""
+    summary = MagicMock()
+    summary.statistic.params = {
+        "covariate_adjustment": {"metric": "my_metric", "period": "preenrollment_week"}
+    }
+    summary.metric.depends_on = None
+
+    analysis = _empty_analysis(experiments)
+    prereqs = analysis._subset_metric_table_prerequisites(
+        summary,
+        "normandy_test_slug_enrollments_week_1",
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.WEEK,
+        False,
+    )
+
+    expected_covariate_table = analysis._table_name(
+        AnalysisPeriod.PREENROLLMENT_WEEK.value, 1, AnalysisBasis.ENROLLMENTS
+    )
+    assert prereqs == [expected_covariate_table]
+
+
+def test_subset_metric_table_prerequisites_covariate_skipped_for_preenrollment_period(experiments):
+    """When the current period is a preenrollment period, covariate adjustment is not applied,
+    so no extra prerequisite table should be returned."""
+    summary = MagicMock()
+    summary.statistic.params = {
+        "covariate_adjustment": {"metric": "my_metric", "period": "preenrollment_week"}
+    }
+    summary.metric.depends_on = None
+
+    prereqs = _empty_analysis(experiments)._subset_metric_table_prerequisites(
+        summary,
+        "normandy_test_slug_enrollments_preenrollment_week_1",
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.PREENROLLMENT_WEEK,
+        False,
+    )
+
+    assert prereqs == []
+
+
+def test_subset_metric_table_prerequisites_discrete_depends_on(experiments):
+    """For a discrete ratio metric whose dependencies span two data sources, the prerequisite
+    list contains the cross-DS dependency table but not the primary table."""
+    upstream_a = Metric(
+        name="upstream_a",
+        data_source=DataSource(name="data_source_a", from_expression="test.test"),
+        select_expression="test",
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+    )
+    upstream_b = Metric(
+        name="upstream_b",
+        data_source=DataSource(name="data_source_b", from_expression="test.test"),
+        select_expression="test",
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+    )
+
+    from jetstream.statistics import Summary as JetstreamSummary
+
+    ratio_metric = Metric(
+        name="ratio_metric",
+        data_source=DataSource(name="data_source_a", from_expression="test.test"),
+        select_expression=None,
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+        depends_on=[
+            JetstreamSummary(upstream_a, None, None),
+            JetstreamSummary(upstream_b, None, None),
+        ],
+    )
+
+    summary = MagicMock()
+    summary.statistic.params = {}
+    summary.metric = ratio_metric
+
+    analysis = _empty_analysis(experiments)
+    primary_table = analysis._table_name(
+        AnalysisPeriod.WEEK.value, 1, AnalysisBasis.ENROLLMENTS, metric="data_source_a"
+    )
+    cross_ds_table = analysis._table_name(
+        AnalysisPeriod.WEEK.value, 1, AnalysisBasis.ENROLLMENTS, metric="data_source_b"
+    )
+
+    prereqs = analysis._subset_metric_table_prerequisites(
+        summary,
+        primary_table,
+        AnalysisBasis.ENROLLMENTS,
+        AnalysisPeriod.WEEK,
+        True,
+    )
+
+    assert cross_ds_table in prereqs
+    assert primary_table not in prereqs
+
+
+def test_run_covariate_bind_wires_cross_period_dep(experiments, monkeypatch):
+    """When a metric uses covariate adjustment from preenrollment_week, run() must pass
+    the preenrollment writer Delayed as a bind prerequisite for the weekly subset task."""
+    config = AnalysisSpec.default_for_experiment(experiments[0], ConfigLoader.configs).resolve(
+        experiments[0], ConfigLoader.configs
+    )
+
+    metric = Metric(
+        name="active_hours",
+        data_source=DataSource(name="clients_daily", from_expression="test.test"),
+        select_expression="SUM(ah)",
+        analysis_bases=[AnalysisBasis.ENROLLMENTS],
+    )
+    cov_statistic = MagicMock()
+    cov_statistic.params = {
+        "covariate_adjustment": {"metric": "active_hours", "period": "preenrollment_week"}
+    }
+    from jetstream.statistics import Summary as JetstreamSummary
+
+    plain_statistic = MagicMock()
+    plain_statistic.params = {}
+    config.metrics = {
+        AnalysisPeriod.WEEK: [JetstreamSummary(metric, cov_statistic, [])],
+        AnalysisPeriod.PREENROLLMENT_WEEK: [JetstreamSummary(metric, plain_statistic, [])],
+    }
+
+    bind_calls: list[tuple] = []
+
+    def capturing_bind(thing, deps):
+        bind_calls.append((thing, list(deps)))
+        return thing
+
+    stats_mock = MagicMock()
+    stats_mock.model_dump.return_value = []
+
+    monkeypatch.setattr("jetstream.analysis.bind", capturing_bind)
+    monkeypatch.setattr("jetstream.analysis.Analysis.ensure_enrollments", Mock())
+    monkeypatch.setattr(
+        "jetstream.analysis.Analysis._get_timelimits_if_ready", MagicMock(return_value=MagicMock())
+    )
+    monkeypatch.setattr("jetstream.analysis.Analysis.calculate_metrics", MagicMock())
+    monkeypatch.setattr(
+        "jetstream.analysis.Analysis.calculate_statistics", MagicMock(return_value=stats_mock)
+    )
+    monkeypatch.setattr("jetstream.analysis.Analysis.counts", MagicMock(return_value=stats_mock))
+    monkeypatch.setattr("jetstream.analysis.Analysis.save_statistics", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.Analysis.publish_view", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.LocalCluster", MagicMock())
+    monkeypatch.setattr("jetstream.analysis.Client", MagicMock())
+
+    Analysis("test", "test", config).run(
+        current_date=dt.datetime(2020, 1, 1, tzinfo=pytz.utc),
+    )
+
+    # At least one bind call for a subset_metric_table task should carry a non-empty deps list,
+    # containing the preenrollment writer as the cross-period prerequisite.
+    subset_binds_with_prereqs = [deps for _, deps in bind_calls if deps]
+    assert subset_binds_with_prereqs, (
+        "Expected at least one subset_metric_table bind call with prerequisites, "
+        "but all bind calls had empty deps. The covariate cross-period edge is missing."
+    )


### PR DESCRIPTION
explicitly makes all necessary metrics tables part of the dask dependencies before running the query in subset_metric_table

fixes #3139 