### PR TITLE
fix: iterate on metrics not ds

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1399,7 +1399,7 @@ class Analysis:
                             continue
 
                         if statistics_only and not self.bigquery.table_exists(metric_table_name):
-                            for metric in data_source:
+                            for metric in ds_metrics:
                                 logger.warning(
                                     f"Cannot compute only statistics for period {period.value};"
                                     "metrics table doesn't exist"


### PR DESCRIPTION
Bug with statistics_only execution when the metrics don't exist. Luckily, it only affects the logging since execution would fail anyway, but this should fix that.