### PR TITLE
fix: use all-channel dataset for fenix

### DIFF
--- a/platform_config.toml
+++ b/platform_config.toml
@@ -8,7 +8,9 @@ app_id = "firefox-desktop"
 
 # Android platforms configuration
 [platform.fenix]
-app_id = "org.mozilla.fenix"
+# the actual app_id for fenix differs by channel,
+# but the `fenix` dataset joins them all together
+app_id = "fenix"
 
 [platform.focus_android]
 app_id = "org.mozilla.focus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version = "2026.4.1"
+version = "2026.5.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Runs a thing that analyzes experiments"
 readme = "README.md"


### PR DESCRIPTION
This will build the enrollments/exposures queries from the dataset `fenix`, which contains events from all channels, instead of `org_mozilla_fenix`, which only has `nightly`.