### PR TITLE
fix: flush logs less frequently in preview

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1690,7 +1690,6 @@ def preview(
             task_profiling_log_table_id=None,
             task_monitoring_log_table_id=None,
             bq_log_level=logging.INFO,
-            capacity=5,
             log_source=LOG_SOURCE.PREVIEW,
         )
         client.delete_table(f"{project_id}.{dataset_id}.logs_{table}")
@@ -1752,6 +1751,13 @@ def preview(
                     experiments=[exp]
                 ),
             )
+        # make sure we've flushed all the logs
+        for handler in logger.root.handlers:
+            try:
+                handler.flush()
+            except AttributeError:
+                # ignore if log handler does not have 'flush'
+                pass
 
         click.echo(
             "A preview is available at: "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version = "2026.5.1"
+version = "2026.5.2"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Runs a thing that analyzes experiments"
 readme = "README.md"


### PR DESCRIPTION
We had the log capacity set to 5 for preview. Presumably this was to flush logs more regularly, but a side effect is that it can easily hit UPDATE rate limits on the log table in BigQuery.

This change uses the default log capacity, but then explicitly flushes all the logs before finishing the task. This is the same thing we do in `export_logs_to_json` before exporting the logs.

fixes #3187