### PR TITLE
fix: set enrollment end date for preview

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1114,7 +1114,7 @@ class Analysis:
         self.start_time = datetime.now(tz=pytz.utc)
         logger.info(
             f"Analysis.run invoked at {self.start_time}"
-            f"for experiment {self.config.experiment.normandy_slug} and date {current_date.date()}"
+            f" for experiment {self.config.experiment.normandy_slug} and date {current_date.date()}"
         )
 
         self.check_runnable(current_date)

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1620,7 +1620,7 @@ def preview(
             normandy_slug=experiment.normandy_slug if experiment else slug,
             type=experiment.type if experiment else "v6",
             status="Live",
-            start_date=start_date - timedelta(days=3),  # subtract enrollment days
+            start_date=start_date - timedelta(days=enrollment_period),  # subtract enrollment days
             end_date=end_date,
             proposed_enrollment=enrollment_period,
             branches=experiment.branches if experiment else [Branch(slug="control", ratio=1)],
@@ -1630,7 +1630,8 @@ def preview(
             app_id=experiment.app_id if experiment else PLATFORM_CONFIGS[platform].app_id,
             outcomes=experiment.outcomes if experiment else [],
             segments=experiment.segments if experiment else [],
-            enrollment_end_date=None,
+            # end enrollment on the day before the analysis start date
+            enrollment_end_date=start_date - timedelta(days=1),
         )
 
         spec = AnalysisSpec.default_for_experiment(experiment, config_getter.configs)

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -182,6 +182,12 @@ class ExperimentCollection:
                 draft_experiments_json = [draft_experiments_json]
 
             for draft_experiment in draft_experiments_json:
+                if (
+                    "detail" in draft_experiment
+                    and draft_experiment["detail"] == "No NimbusExperiment matches the given query."
+                ):
+                    logger.warning(f"No draft experiment found with slug {slug}, skipping...")
+                    continue
                 try:
                     draft_experiments.append(
                         NimbusExperiment.from_dict(draft_experiment).to_experiment()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "mozilla-jetstream"
 # This project does not issue regular releases, only when there
 # are changes that would be meaningful to our (few) dependents.
-version = "2026.5.2"
+version = "2026.5.3"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Runs a thing that analyzes experiments"
 readme = "README.md"


### PR DESCRIPTION
Some fixes/updates for `preview`:
- `start_date` subtracts the specified `enrollment_period` instead of static 3 days
- `enrollment_end_date`  is the `start_date - 1` instead of `None`
- clean up noisy draft experiment logging when experiment is not found in draft
