### PR TITLE
fix: memory_request click convert fn properly handles int default

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -677,8 +677,8 @@ class ClickGBString(click.ParamType):
     name = "gb_str_from_int"
 
     def convert(self, value, param, ctx) -> str:
-        # if value already ends with G, assume the rest is an int
-        int_value = int(value[0:-1]) if value[-1] == "G" else int(value)
+        # if value is str and ends with G, assume the rest is an int
+        int_value = int(value[0:-1]) if isinstance(value, str) and value[-1] == "G" else int(value)
         if int_value >= 1 and int_value <= 60:
             return f"{int_value}G"
 


### PR DESCRIPTION
The default value (i.e., not providing `--memory-request` at all) is an int and the `convert` function errors on this when attempting to call `value[-1]`. Adding an `isinstance` check fixes it.