### PR TITLE
fix: dedupe identity metric for discrete metrics

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1481,6 +1481,7 @@ class Analysis:
                     # create the full list of metrics to compute
                     # metrics = config_metrics
                     logger.debug(f"COMPUTING METRICS: {[m.name for m in config_metrics]}")
+                    counted_segments: set[str] = set()
                     for data_source, ds_metrics in metrics_by_ds.items():
                         metric_table = self.calculate_metric_for_ds(
                             exp,
@@ -1575,9 +1576,11 @@ class Analysis:
                                     period,
                                 ).model_dump(warnings=False)
 
-                            segment_results.root += self.counts(
-                                segment_data, segment, analysis_basis
-                            ).model_dump(warnings=False)
+                            if segment not in counted_segments:
+                                segment_results.root += self.counts(
+                                    segment_data, segment, analysis_basis
+                                ).model_dump(warnings=False)
+                                counted_segments.add(segment)
 
                     # metrics are done: now iterate over the depends_on metrics
                     for summary in summary_metrics:

--- a/jetstream/tests/integration/test_analysis_integration.py
+++ b/jetstream/tests/integration/test_analysis_integration.py
@@ -284,6 +284,12 @@ class TestAnalysisIntegration:
             from_expression=f"`{project_id}.test_data.clients_daily`",
         )
 
+        # use second DS to ensure we aren't duplicating counts
+        test_clients_last_seen = DataSource(
+            name="clients_last_seen",
+            from_expression=f"`{project_id}.test_data.clients_last_seen`",
+        )
+
         test_active_hours = Metric(
             name="active_hours",
             data_source=test_clients_daily,
@@ -293,7 +299,7 @@ class TestAnalysisIntegration:
 
         test_active_hours_doubled = Metric(
             name="active_hours_doubled",
-            data_source=test_clients_daily,
+            data_source=test_clients_last_seen,
             select_expression=f"{agg_sum('active_hours_sum')} * 2",
             analysis_bases=[AnalysisBasis.EXPOSURES, AnalysisBasis.ENROLLMENTS],
         )


### PR DESCRIPTION
After adding discrete metrics functionality, we've been duplicating the identity counts by doing one per data source (per [branch, segment, analysis_basis]). This fix should ensure we only do this once per segment.