### PR TITLE
feat: more useful logging for all-zero cases in mean_lm

### DIFF
--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -476,6 +476,53 @@ class LinearModelMean(Statistic):
             )
             covariate_col_label = None
 
+        # Detect a zero reference-branch mean before it causes division-by-zero in
+        # compare_branches_lm's relative uplift, mirroring its pooled clipping.
+        threshold_quantile = 1 - self.drop_highest
+        if df is not None and isinstance(df, DataFrame) and "branch" in df and metric in df:
+            ref_values = df.loc[df["branch"] == reference_branch, metric].dropna()
+        else:
+            ref_values = None
+
+        if ref_values is not None and not ref_values.empty:
+            threshold = df[metric].dropna().quantile(threshold_quantile)
+            if np.issubdtype(df[metric].dtype, np.integer):
+                threshold = int(np.ceil(threshold))
+            post_trim = ref_values.clip(upper=threshold)
+
+            if (post_trim == 0).all():
+                n = len(ref_values)
+                if (ref_values == 0).all():
+                    reason = (
+                        f"reference branch '{reference_branch}' has {n} non-null "
+                        f"client(s) and all values for metric '{metric}' are zero"
+                    )
+                else:
+                    reason = (
+                        f"reference branch '{reference_branch}' has {n} non-null "
+                        f"client(s) but metric '{metric}' became all zeroes after "
+                        f"outlier trimming (pooled {threshold_quantile:.3f} quantile "
+                        f"threshold is {threshold})"
+                    )
+                msg = (
+                    f"Skipping computing statistic {self.name()} for metric "
+                    f"{metric}: {reason}. Cannot compute because the "
+                    "relative uplift (treatment/reference) is undefined "
+                    "when the reference mean is zero."
+                )
+                logger.exception(
+                    msg,
+                    exc_info=StatisticComputationException(msg),
+                    extra={
+                        "experiment": experiment.normandy_slug if experiment is not None else None,
+                        "metric": metric,
+                        "statistic": self.name(),
+                        "analysis_basis": analysis_basis.value,
+                        "segment": segment,
+                    },
+                )
+                return StatisticResultCollection.model_validate([])
+
         ma_result = mozanalysis.frequentist_stats.linear_models.compare_branches_lm(
             df,
             col_label=metric,

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import logging
 import re
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -83,6 +84,39 @@ class TestStatistics:
         assert treatment_result.point < control_result.point
         assert treatment_result.lower
         assert treatment_result.upper
+
+    def test_linear_model_mean_all_zero_reference_branch(self, caplog):
+        """When the reference branch has no non-zero values, log a clear warning."""
+        stat = LinearModelMean()
+        test_data = pd.DataFrame(
+            {
+                "branch": ["treatment"] * 10 + ["control"] * 10,
+                "value": list(range(1, 11)) + [0] * 10,
+            }
+        )
+        with caplog.at_level(logging.ERROR, logger="jetstream.statistics"):
+            results = stat.transform(
+                test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
+            )
+        assert len(results.root) == 0
+        assert any("all values for metric 'value' are zero" in r.message for r in caplog.records)
+
+    def test_linear_model_mean_reference_branch_zeroed_by_trimming(self, caplog):
+        """When outlier clipping zeroes out the reference branch, log a clear warning."""
+        stat = LinearModelMean()
+        # The non-zero value in control branch is clipped by the outlier trimming
+        test_data = pd.DataFrame(
+            {
+                "branch": ["treatment"] * 101 + ["control"] * 101,
+                "value": [0] * 101 + [0] * 100 + [1],
+            }
+        )
+        with caplog.at_level(logging.ERROR, logger="jetstream.statistics"):
+            results = stat.transform(
+                test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
+            )
+        assert len(results.root) == 0
+        assert any("after outlier trimming" in r.message for r in caplog.records)
 
     @pytest.mark.parametrize(
         "period", [AnalysisPeriod.PREENROLLMENT_WEEK, AnalysisPeriod.PREENROLLMENT_DAYS_28]


### PR DESCRIPTION
Because
- there have been a bunch of recent experiments with very small segment populations
- very small segment populations means higher chance of control branch having only zeroes for a given metric
- all zero values leads to an error like `Error while computing statistic linear_model_mean for metric {metric}: UDF failed: float division by zero`

We can instead check for this scenario upfront and a) skip the computation and b) log something more indicative of the cause (no non-zero values) instead of result (failure inside stats code).

This also adds an extra check to differentiate the case where the all-zero scenario was caused by threshold trimming.