### PR TITLE
Fix analysis_period_length in pre treatments

### DIFF
--- a/jetstream/analysis.py
+++ b/jetstream/analysis.py
@@ -1386,9 +1386,9 @@ class Analysis:
 
             segment_labels = ["all"] + [s.name for s in self.config.experiment.segments]
             analysis_length_dates = 1
-            if period.value == AnalysisPeriod.OVERALL:
+            if period == AnalysisPeriod.OVERALL:
                 analysis_length_dates = time_limits.analysis_length_dates
-            elif period.value == AnalysisPeriod.WEEK:
+            elif period == AnalysisPeriod.WEEK:
                 analysis_length_dates = 7
 
             for analysis_basis in analysis_bases:

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -78,10 +78,10 @@ class Summary:
                     continue
                 if pre_treatment.name() == pre_treatment_conf.name:
                     found = True
-                    # inject analysis_period_length from experiment
-                    pre_treatment.analysis_period_length = analysis_period_length or 1
+                    pre_treatment_instance = pre_treatment.from_dict(pre_treatment_conf.args)
+                    pre_treatment_instance.analysis_period_length = analysis_period_length or 1
 
-                    pre_treatments.append(pre_treatment.from_dict(pre_treatment_conf.args))
+                    pre_treatments.append(pre_treatment_instance)
 
             if not found:
                 raise ValueError(f"Could not find pre-treatment {pre_treatment_conf.name}.")

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -52,6 +52,37 @@ class SAME_DF:
 
 
 class TestStatistics:
+    def test_summary_from_config_injects_analysis_period_length(self):
+        """normalize_over_analysis_period must receive the experiment's analysis period length
+        on the resulting pre-treatment instance. Otherwise values are divided by the default
+        of 1 (a no-op) and weekly/overall metrics are not scaled down."""
+        from metric_config_parser.metric import Metric as ConfigMetric
+        from metric_config_parser.metric import Summary as ConfigSummary
+        from metric_config_parser.pre_treatment import PreTreatmentReference
+        from metric_config_parser.statistic import Statistic as ConfigStatistic
+
+        from jetstream.statistics import Summary
+
+        summary_config = ConfigSummary(
+            metric=ConfigMetric(
+                name="dau_per_1000_clients", data_source=None, select_expression="1"
+            ),
+            statistic=ConfigStatistic(name="bootstrap_mean", params={}),
+            pre_treatments=[
+                PreTreatmentReference(name="normalize_over_analysis_period", args={})
+            ],
+        )
+
+        summary = Summary.from_config(summary_config, 7, AnalysisPeriod.WEEK)
+
+        (pre_treatment,) = summary.pre_treatments
+        assert pre_treatment.analysis_period_length == 7
+
+        # the pre-treatment actually scales values by the period length (7-day week)
+        df = pd.DataFrame({"dau_per_1000_clients": [1400.0, 7000.0]})
+        out = pre_treatment.apply(df, "dau_per_1000_clients")
+        assert list(out["dau_per_1000_clients"]) == [200.0, 1000.0]
+
     def test_bootstrap_means(self):
         stat = BootstrapMean(num_samples=10)
         test_data = pd.DataFrame(

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -68,9 +68,7 @@ class TestStatistics:
                 name="dau_per_1000_clients", data_source=None, select_expression="1"
             ),
             statistic=ConfigStatistic(name="bootstrap_mean", params={}),
-            pre_treatments=[
-                PreTreatmentReference(name="normalize_over_analysis_period", args={})
-            ],
+            pre_treatments=[PreTreatmentReference(name="normalize_over_analysis_period", args={})],
         )
 
         summary = Summary.from_config(summary_config, 7, AnalysisPeriod.WEEK)


### PR DESCRIPTION
Fixes https://github.com/mozilla/jetstream/issues/3279

The `analysis_period_length` was incorrectly passed into the `PreTreatment` class instance. The parameter was passed before the class got instantiated, effectively overriding the parameter value.

Another bug is that the `AnalysisPeriod` enum was compared against a string value when setting the `analysis_period_length`