### PR TITLE
Fix experiment iteration for rerun

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1328,7 +1328,7 @@ def rerun_config_changed(
 
     # get the experiments from Experimenter API that are explicitly marked for rerun
     # and are out of date
-    all_experiments = ExperimentCollection.from_experimenter()
+    all_experiments = ExperimentCollection.from_experimenter().experiments
     rerun_experiments = [exp for exp in all_experiments if exp.do_rerun]
     client = BigQueryClient(project_id, dataset_id)
     for exp in rerun_experiments:


### PR DESCRIPTION
Fix for https://github.com/mozilla/jetstream/pull/3258 which is causing

```
  File "/usr/local/lib/python3.11/site-packages/jetstream/cli.py", line 1332, in rerun_config_changed
    rerun_experiments = [exp for exp in all_experiments if exp.do_rerun]
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'ExperimentCollection' object is not iterable
```

([error](https://workflow.telemetry.mozilla.org/dags/jetstream/grid?dag_run_id=scheduled__2026-07-12T04%3A00%3A00%2B00%3A00&task_id=jetstream_run_config_changed&tab=logs))