### PR TITLE
chore: clarify trimming/clipping in stats

### DIFF
--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -492,9 +492,9 @@ class LinearModelMean(Statistic):
             # BigQuery are handled; np.issubdtype raises on pandas extension dtypes
             if pd.api.types.is_integer_dtype(df[metric].dtype):
                 threshold = int(np.ceil(threshold))
-            post_trim = ref_values.clip(upper=threshold)
+            post_clip = ref_values.clip(upper=threshold)
 
-            if (post_trim == 0).all():
+            if (post_clip == 0).all():
                 n = len(ref_values)
                 if (ref_values == 0).all():
                     reason = (
@@ -505,7 +505,7 @@ class LinearModelMean(Statistic):
                     reason = (
                         f"reference branch '{reference_branch}' has {n} non-null "
                         f"client(s) but metric '{metric}' became all zeroes after "
-                        f"outlier trimming (pooled {threshold_quantile:.3f} quantile "
+                        f"outlier clipping (pooled {threshold_quantile:.3f} quantile "
                         f"threshold is {threshold})"
                     )
                 msg = (

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -388,9 +388,16 @@ def flatten_simple_compare_branches_result(
 
 @attr.s(auto_attribs=True)
 class BootstrapMean(Statistic):
+    """Computes mean statistic using bootstrap.
+
+    Parameters:
+    - num_samples (int): Default 10000.
+    - drop_highest (float): threshold above which values will be *clipped*
+        0.0 means no values will be clipped. Default 0.005.
+    - confidence_interval (float): Default 0.95.
+    """
+
     num_samples: int = 10000
-    # drop_highest is the threshold above which values will be *clipped*
-    # 0.0 means no values will be clipped
     drop_highest: float = 0.005
     confidence_interval: float = 0.95
 
@@ -426,8 +433,15 @@ class BootstrapMean(Statistic):
 
 @attr.s(auto_attribs=True)
 class LinearModelMean(Statistic):
-    # drop_highest is the threshold above which values will be *clipped*
-    # 0.0 means no values will be clipped
+    """Computes mean statistic using linear model.
+
+    Parameters:
+    - drop_highest (float): threshold above which values will be *clipped*
+        0.0 means no values will be clipped. Default 0.005.
+    - covariate_adjustment (dict[str, str]): currently used keys are "metric" as the
+        name of the metric, and "period" as the (preenrollment) period to pull from
+    """
+
     drop_highest: float = attr.ib(default=0.005, validator=attr.validators.instance_of(float))
     # currently used keys are "metric" as the name of the metric
     # and "period" as the (preenrollment) period to pull from
@@ -555,8 +569,15 @@ class LinearModelMean(Statistic):
 
 @attr.s(auto_attribs=True)
 class PerClientDAUImpact(LinearModelMean):
-    # drop_highest is the threshold above which values will be *clipped*
-    # 0.0 means no values will be clipped
+    """Computes the per-client DAU impact using linear model mean.
+    Only returns relative uplift, strips absolute data points intentionally
+    (see comments inline for details).
+
+    Parameters:
+    - drop_highest (float): threshold above which values will be *clipped*
+        0.0 means no values will be clipped. Default 0.0.
+    """
+
     drop_highest: float = 0.0
 
     def transform(
@@ -1014,11 +1035,20 @@ class EmpiricalCDF(Statistic):
 
 @attr.s(auto_attribs=True, kw_only=True)
 class PopulationRatio(Statistic):
+    """Computes mean statistic using linear model.
+
+    Parameters:
+    - numerator (str): column label (metric name) from dataframe
+    - denominator (str): column label (metric name) from dataframe
+    - confidence_interval (float): Default 0.95.
+    - drop_highest (float): threshold above which values will be *clipped*
+        0.0 means no values will be clipped. Default 0.005.
+    - num_samples (int): Default 10000.
+    """
+
     numerator: str
     denominator: str
     confidence_interval: float = 0.95
-    # drop_highest is the threshold above which values will be *clipped*
-    # 0.0 means no values will be clipped
     drop_highest: float = 0.005
     num_samples: int = 10000
 

--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -389,6 +389,8 @@ def flatten_simple_compare_branches_result(
 @attr.s(auto_attribs=True)
 class BootstrapMean(Statistic):
     num_samples: int = 10000
+    # drop_highest is the threshold above which values will be *clipped*
+    # 0.0 means no values will be clipped
     drop_highest: float = 0.005
     confidence_interval: float = 0.95
 
@@ -424,6 +426,8 @@ class BootstrapMean(Statistic):
 
 @attr.s(auto_attribs=True)
 class LinearModelMean(Statistic):
+    # drop_highest is the threshold above which values will be *clipped*
+    # 0.0 means no values will be clipped
     drop_highest: float = attr.ib(default=0.005, validator=attr.validators.instance_of(float))
     # currently used keys are "metric" as the name of the metric
     # and "period" as the (preenrollment) period to pull from
@@ -551,6 +555,8 @@ class LinearModelMean(Statistic):
 
 @attr.s(auto_attribs=True)
 class PerClientDAUImpact(LinearModelMean):
+    # drop_highest is the threshold above which values will be *clipped*
+    # 0.0 means no values will be clipped
     drop_highest: float = 0.0
 
     def transform(
@@ -1011,6 +1017,8 @@ class PopulationRatio(Statistic):
     numerator: str
     denominator: str
     confidence_interval: float = 0.95
+    # drop_highest is the threshold above which values will be *clipped*
+    # 0.0 means no values will be clipped
     drop_highest: float = 0.005
     num_samples: int = 10000
 

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -149,10 +149,10 @@ class TestStatistics:
         assert len(results.root) == 0
         assert any("all values for metric 'value' are zero" in r.message for r in caplog.records)
 
-    def test_linear_model_mean_reference_branch_zeroed_by_trimming(self, caplog):
+    def test_linear_model_mean_reference_branch_zeroed_by_clipping(self, caplog):
         """When outlier clipping zeroes out the reference branch, log a clear warning."""
         stat = LinearModelMean()
-        # The non-zero value in control branch is clipped by the outlier trimming
+        # The non-zero value in control branch is clipped by the outlier clipping
         test_data = pd.DataFrame(
             {
                 "branch": ["treatment"] * 101 + ["control"] * 101,
@@ -164,7 +164,7 @@ class TestStatistics:
                 test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
             )
         assert len(results.root) == 0
-        assert any("after outlier trimming" in r.message for r in caplog.records)
+        assert any("after outlier clipping" in r.message for r in caplog.records)
 
     @pytest.mark.parametrize(
         "period", [AnalysisPeriod.PREENROLLMENT_WEEK, AnalysisPeriod.PREENROLLMENT_DAYS_28]


### PR DESCRIPTION
We are **clipping** not **trimming** and so should be consistent with terminology.

see `filter_outliers` in mozanalysis for [reference](https://github.com/mozilla/mozanalysis/blob/66da3c6c4cf911d8313a6484468f9b698feed4c0/src/mozanalysis/utils.py#L59-L81)