### PR TITLE
chore: make argo client code more resilient to unexpected workflow structure

### DIFF
--- a/jetstream/argo.py
+++ b/jetstream/argo.py
@@ -82,22 +82,20 @@ def submit_workflow(
                 workflow["metadata"]["namespace"], workflow["metadata"]["name"]
             )
 
-            if (
-                "status" in workflow
-                and workflow["status"]
-                and "finishedAt" in workflow["status"]
-                and workflow["status"]["finishedAt"] is not None
-            ):
+            status = workflow.get("status") or {}
+            if status.get("finishedAt") is not None:
                 finished = True
-                if workflow["status"]["phase"] == "Failed":
-                    raise Exception(f"Workflow execution failed: {workflow['status']}")
+                if status.get("phase") == "Failed":
+                    raise Exception(f"Workflow execution failed: {status}")
 
             # adjust wait time, too many requests might hit the request limit and raise
             # HTTPSConnectionPool(host='##.##.##.##', port=443): Max retries exceeded with url
             time.sleep(10)
 
     # check status of pods
-    if "status" in workflow and workflow["status"] and workflow["status"]["nodes"]:
+    pods_failed: list[str] = []
+    nodes = (workflow.get("status") or {}).get("nodes") or {}
+    if nodes:
         pods_succeeded = {
             # name contains the step name and all parameter values, e.g.
             # jetstream-zvbcs[0].ensure-enrollments-and-analyze(0:dates:[\"2021-03-25\"],
@@ -105,15 +103,16 @@ def submit_workflow(
             # [0].analyse-experiment(0)
             # the end of the name "(0)" indicates the retry number
             re.sub(r"\(\d\)", "", node["name"])  # remove retry number
-            for _, node in workflow["status"]["nodes"].items()
-            if node["type"] == "Pod" and node["phase"] == "Succeeded"
+            for node in nodes.values()
+            if node.get("type") == "Pod" and node.get("phase") == "Succeeded" and "name" in node
         }
 
         pods_failed = [
             node["name"]
-            for _, node in workflow["status"]["nodes"].items()
-            if node["type"] == "Pod"
-            and node["phase"] == "Failed"
+            for node in nodes.values()
+            if node.get("type") == "Pod"
+            and node.get("phase") == "Failed"
+            and "name" in node
             and re.sub(r"\(\d\)", "", node["name"]) not in pods_succeeded
         ]
 

--- a/jetstream/tests/test_argo.py
+++ b/jetstream/tests/test_argo.py
@@ -1,70 +1,45 @@
 from textwrap import dedent
+from unittest import mock
 
 import yaml
 
 from jetstream import argo
 from jetstream.cli import ArgoExecutorStrategy
 
+MINIMAL_WORKFLOW = dedent(
+    """
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+        generateName: jetstream-
+    spec:
+        entrypoint: jetstream
+        arguments:
+            parameters:
+            - name: date
+    """
+)
+
 
 class TestArgo:
     def test_apply_parameters(self):
-        config_str = dedent(
-            """
-            apiVersion: argoproj.io/v1alpha1
-            kind: Workflow
-            metadata:
-                generateName: jetstream-
-            spec:
-                entrypoint: jetstream
-                arguments:
-                    parameters:
-                    - name: date
-            """
-        )
-
-        manifest = yaml.safe_load(config_str)
+        manifest = yaml.safe_load(MINIMAL_WORKFLOW)
         updated_manifest = argo.apply_parameters(manifest, {"date": "2020-01-01"})
         assert updated_manifest["spec"]["arguments"]["parameters"][0]["name"] == "date"
         assert updated_manifest["spec"]["arguments"]["parameters"][0]["value"] == "2020-01-01"
 
     def test_apply_parameters_overwrite(self):
-        config_str = dedent(
-            """
-            apiVersion: argoproj.io/v1alpha1
-            kind: Workflow
-            metadata:
-                generateName: jetstream-
-            spec:
-                entrypoint: jetstream
-                arguments:
-                    parameters:
-                    - name: date
-                      value: 2020-12-12
-            """
-        )
+        manifest = yaml.safe_load(MINIMAL_WORKFLOW)
+        manifest["spec"]["arguments"]["parameters"][0]["value"] = "2020-12-12"
 
-        manifest = yaml.safe_load(config_str)
         updated_manifest = argo.apply_parameters(manifest, {"date": "2020-01-01"})
         assert updated_manifest["spec"]["arguments"]["parameters"][0]["name"] == "date"
         assert updated_manifest["spec"]["arguments"]["parameters"][0]["value"] == "2020-01-01"
 
     def test_apply_parameters_add(self):
-        config_str = dedent(
-            """
-            apiVersion: argoproj.io/v1alpha1
-            kind: Workflow
-            metadata:
-                generateName: jetstream-
-            spec:
-                entrypoint: jetstream
-                arguments:
-                    parameters:
-                    - name: date
-                      value: 2020-12-12
-            """
-        )
+        manifest = yaml.safe_load(MINIMAL_WORKFLOW)
+        manifest["spec"]["arguments"]["parameters"][0]["value"] = "2020-12-12"
 
-        manifest = yaml.safe_load(config_str)
         updated_manifest = argo.apply_parameters(manifest, {"date": "2020-01-01", "slug": "test"})
         assert updated_manifest["spec"]["arguments"]["parameters"][0]["name"] == "date"
         assert updated_manifest["spec"]["arguments"]["parameters"][0]["value"] == "2020-01-01"
@@ -89,4 +64,40 @@ class TestArgo:
                 updated_manifest["spec"]["arguments"]["parameters"][0]["value"]
                 == '[{"date": "2020-01-01", "slug": "a", "image_hash": "abc"}, '
                 + '{"date": "2020-01-02", "slug": "b", "image_hash": "abc"}]'
+            )
+
+    def test_submit_workflow_status_without_nodes(self, tmp_path):
+        workflow_file = tmp_path / "workflow.yaml"
+        workflow_file.write_text(MINIMAL_WORKFLOW)
+
+        created_workflow = {
+            "metadata": {"namespace": "argo", "name": "jetstream-abc"},
+            "status": {"phase": "Succeeded"},
+        }
+        with mock.patch.object(argo.ArgoApi, "create_workflow", return_value=created_workflow):
+            assert (
+                argo.submit_workflow(
+                    "project", "zone", "cluster", workflow_file, {"date": "2020-01-01"}
+                )
+                is True
+            )
+
+    def test_submit_workflow_nodes_failure_detected(self, tmp_path):
+        workflow_file = tmp_path / "workflow.yaml"
+        workflow_file.write_text(MINIMAL_WORKFLOW)
+
+        created_workflow = {
+            "metadata": {"namespace": "argo", "name": "jetstream-abc"},
+            "status": {
+                "nodes": {
+                    "node1": {"name": "step-one(0)", "type": "Pod", "phase": "Failed"},
+                }
+            },
+        }
+        with mock.patch.object(argo.ArgoApi, "create_workflow", return_value=created_workflow):
+            assert (
+                argo.submit_workflow(
+                    "project", "zone", "cluster", workflow_file, {"date": "2020-01-01"}
+                )
+                is False
             )


### PR DESCRIPTION
There was a recent Airflow failure in jetstream with the error:
```
File "/usr/local/lib/python3.11/site-packages/jetstream/argo.py", line 100, in submit_workflow
     if "status" in workflow and workflow["status"] and workflow["status"]["nodes"]:
```

This should make the Argo client more resilient to these types of errors, and updates the tests.