### PR TITLE
fix: do_rerun captured from api and properly analyzed in rerun_config_changed

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -1330,6 +1330,7 @@ def rerun_config_changed(
     # and are out of date
     all_experiments = ExperimentCollection.from_experimenter().experiments
     rerun_experiments = [exp for exp in all_experiments if exp.do_rerun]
+    rerun_slugs = set()
     client = BigQueryClient(project_id, dataset_id)
     for exp in rerun_experiments:
         first_updated = client.experiment_table_first_updated(exp.normandy_slug)
@@ -1337,7 +1338,7 @@ def rerun_config_changed(
         if first_updated is None or (
             exp.do_rerun_timestamp is not None and first_updated < exp.do_rerun_timestamp
         ):
-            experiment_slugs.add(exp.normandy_slug)
+            rerun_slugs.add(exp.normandy_slug)
 
     # update the table timestamps which indicate whether a experiment needs to be rerun
     client = BigQueryClient(project_id, dataset_id)
@@ -1345,6 +1346,12 @@ def rerun_config_changed(
         client.touch_tables(slug)
         # delete existing tables
         client.delete_experiment_tables(slug, analysis_periods, recreate_enrollments)
+    for slug in rerun_slugs:
+        client.touch_tables(slug)
+        # do_rerun experiments only do OVERALL and should always recreate enrollments
+        client.delete_experiment_tables(slug, [AnalysisPeriod.OVERALL], recreate_enrollments=True)
+        # add to full list so they get analyzed
+        experiment_slugs.add(slug)
 
     if argo:
         strategy = ArgoExecutorStrategy(
@@ -1367,7 +1374,7 @@ def rerun_config_changed(
         dataset_id=dataset_id,
         bucket=bucket,
         date=All,
-        experiment_slugs=experiment_slugs,
+        experiment_slugs=list(experiment_slugs),
         recreate_enrollments=recreate_enrollments,
     ).execute(
         strategy=strategy,

--- a/jetstream/experimenter.py
+++ b/jetstream/experimenter.py
@@ -53,6 +53,8 @@ class NimbusExperiment:
     enrollmentEndDate: dt.datetime | None = None
     isEnrollmentPaused: bool | None = None
     isRollout: bool = False
+    doRerun: bool = False
+    doRerunTimestamp: dt.datetime | None = None
 
     @property
     def appName(self) -> str:
@@ -84,6 +86,9 @@ class NimbusExperiment:
                 converter,
                 _appName=cattr.override(rename="appName"),
                 _appId=cattr.override(rename="appId"),
+                doRerunTimestamp=cattr.override(
+                    struct_hook=lambda num, _: dt.datetime.fromisoformat(num) if num else None
+                ),
             ),
         )
         return converter.structure(d, cls)
@@ -119,6 +124,8 @@ class NimbusExperiment:
             is_enrollment_paused=bool(self.isEnrollmentPaused),
             is_rollout=self.isRollout,
             bucket_config=self.bucketConfig,
+            do_rerun=self.doRerun,
+            do_rerun_timestamp=self.doRerunTimestamp,
         )
 
 

--- a/jetstream/tests/data/NimbusExperiment_v1.0.json
+++ b/jetstream/tests/data/NimbusExperiment_v1.0.json
@@ -174,6 +174,22 @@
         "filter_expression": {
           "type": "string",
           "description": "This is NOT used by Nimbus, but has special functionality in Remote Settings.\nSee https://remote-settings.readthedocs.io/en/latest/target-filters.html#how"
+        },
+        "isRollout": {
+          "type": "boolean",
+          "description": "Whether the experiment is a rollout (slow-rollback)."
+        },
+        "doRerun": {
+          "type": "boolean",
+          "description": "True if analysis should be fully rerun."
+        },
+        "doRerunTimestamp": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Fully rerun analysis if experiment tables are older than this timestamp.",
+          "format": "date-time"
         }
       },
       "required": [

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -280,6 +280,69 @@ class TestCli:
 
             assert result.exit_code == 0
 
+    def test_rerun_config_changed_do_rerun_overall_only(self, runner, monkeypatch, bq_client_mock):
+        monkeypatch.setattr(ConfigLoader, "with_configs_from", lambda *a, **kw: ConfigLoader)
+        monkeypatch.setattr(ConfigLoader, "updated_configs", lambda *a, **kw: [])
+        monkeypatch.setattr(ConfigLoader, "updated_defaults", lambda *a, **kw: [])
+
+        bq_client_mock.return_value.reset_mock()
+        bq_client_mock.return_value.experiment_table_first_updated.return_value = dt.datetime(
+            2023, 1, 1, tzinfo=UTC
+        )
+
+        rerun_experiment = Experiment(
+            experimenter_slug=None,
+            normandy_slug="holdback_experiment",
+            type="v6",
+            status="Live",
+            branches=[Branch(slug="treatment", ratio=1), Branch(slug="control", ratio=1)],
+            start_date=dt.datetime(2020, 1, 1, tzinfo=UTC),
+            end_date=dt.datetime(2021, 2, 1, tzinfo=UTC),
+            proposed_enrollment=None,
+            reference_branch="control",
+            is_high_population=False,
+            app_name="firefox_desktop",
+            app_id="firefox-desktop",
+            do_rerun=True,
+            # after the mocked `experiment_table_first_updated`, so it's considered stale
+            do_rerun_timestamp=dt.datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        def experiment_getter(*a, **kw):
+            return experimenter.ExperimentCollection([rerun_experiment])
+
+        monkeypatch.setattr("jetstream.cli.ExperimentCollection.from_experimenter", experiment_getter)
+        monkeypatch.setitem(
+            cli.AnalysisExecutor.execute.__kwdefaults__, "experiment_getter", experiment_getter
+        )
+
+        captured = {}
+
+        class MockStrategy:
+            def __init__(self, project_id, dataset_id, bucket=None, log_config=None, **kwargs):
+                captured["analysis_periods"] = kwargs.get("analysis_periods")
+
+            def execute(self, worklist, configuration_map=None):
+                captured["worklist"] = worklist
+                return True
+
+        monkeypatch.setattr("jetstream.cli.SerialExecutorStrategy", MockStrategy)
+
+        result = runner.invoke(
+            cli.cli,
+            ["rerun-config-changed", "--project_id", "test-project", "--dataset_id", "test_dataset"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+        # do_rerun experiments only rerun OVERALL and always recreate enrollments
+        bq_client_mock.return_value.delete_experiment_tables.assert_any_call(
+            "holdback_experiment", [AnalysisPeriod.OVERALL], recreate_enrollments=True
+        )
+
+        # ensure holdback is in analysis list after deleting tables
+        analyzed_slugs = {config.experiment.normandy_slug for config, _ in captured["worklist"]}
+        assert "holdback_experiment" in analyzed_slugs
+
 
 @attr.s(auto_attribs=True)
 class DummyExecutorStrategy:

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -307,10 +307,13 @@ class TestCli:
             # after the mocked `experiment_table_first_updated`, so it's considered stale
             do_rerun_timestamp=dt.datetime(2024, 1, 1, tzinfo=UTC),
         )
+
         def experiment_getter(*a, **kw):
             return experimenter.ExperimentCollection([rerun_experiment])
 
-        monkeypatch.setattr("jetstream.cli.ExperimentCollection.from_experimenter", experiment_getter)
+        monkeypatch.setattr(
+            "jetstream.cli.ExperimentCollection.from_experimenter", experiment_getter
+        )
         monkeypatch.setitem(
             cli.AnalysisExecutor.execute.__kwdefaults__, "experiment_getter", experiment_getter
         )
@@ -329,7 +332,13 @@ class TestCli:
 
         result = runner.invoke(
             cli.cli,
-            ["rerun-config-changed", "--project_id", "test-project", "--dataset_id", "test_dataset"],
+            [
+                "rerun-config-changed",
+                "--project_id",
+                "test-project",
+                "--dataset_id",
+                "test_dataset",
+            ],
             catch_exceptions=False,
         )
         assert result.exit_code == 0, result.output

--- a/jetstream/tests/test_cli.py
+++ b/jetstream/tests/test_cli.py
@@ -331,14 +331,9 @@ class TestCli:
         monkeypatch.setattr("jetstream.cli.SerialExecutorStrategy", MockStrategy)
 
         result = runner.invoke(
-            cli.cli,
-            [
-                "rerun-config-changed",
-                "--project_id",
-                "test-project",
-                "--dataset_id",
-                "test_dataset",
-            ],
+            cli.rerun_config_changed,
+            ["--project_id", "test-project", "--dataset_id", "test_dataset"],
+            obj={"log_config": None},
             catch_exceptions=False,
         )
         assert result.exit_code == 0, result.output

--- a/jetstream/tests/test_experimenter.py
+++ b/jetstream/tests/test_experimenter.py
@@ -46,7 +46,9 @@ NIMBUS_EXPERIMENTER_FIXTURE = r"""
   ],
   "referenceBranch":"control",
   "filter_expression":"env.version|versionCompare('86.0') >= 0",
-  "targeting":"[userId, \"bug-1629098-rapid-please-reject-me-beta-86\"]|bucketSample(0, 100, 10000) && localeLanguageCode == 'en' && region == 'US' && browserSettings.update.channel == 'beta'"
+  "targeting":"[userId, \"bug-1629098-rapid-please-reject-me-beta-86\"]|bucketSample(0, 100, 10000) && localeLanguageCode == 'en' && region == 'US' && browserSettings.update.channel == 'beta'",
+  "doRerun":true,
+  "doRerunTimestamp":"2026-08-21T03:00:00.009942Z"
 },
 {
   "schemaVersion": "1",
@@ -82,7 +84,9 @@ NIMBUS_EXPERIMENTER_FIXTURE = r"""
     }],
   "referenceBranch":"control",
   "filter_expression":"env.version|versionCompare('79.0') >= 0",
-  "targeting":""
+  "targeting":"",
+  "doRerun":false,
+  "doRerunTimestamp":"2026-08-21T03:00:00.009942Z"
 },
 {   
   "id":null,
@@ -332,6 +336,7 @@ def test_with_slug(experiment_collection):
     assert len(experiments.experiments) == 1
     assert experiments.experiments[0].experimenter_slug is None
     assert experiments.experiments[0].normandy_slug == "bug-1629098-rapid-please-reject-me-beta-86"
+    assert experiments.experiments[0].do_rerun is True
 
     experiments = experiment_collection.with_slug(
         "bug-1629000-rapid-testing-rapido-intake-1-release-79"
@@ -363,6 +368,7 @@ def test_convert_nimbus_experiment_to_experiment():
             count=5000,
             total=10000,
         ),
+        doRerun=True,
     )
 
     experiment = nimbus_experiment.to_experiment()
@@ -377,6 +383,7 @@ def test_convert_nimbus_experiment_to_experiment():
     assert experiment.outcomes == []
     assert experiment.segments == []
     assert experiment.is_enrollment_paused is True
+    assert experiment.do_rerun is True
 
 
 def test_fixture_validates():


### PR DESCRIPTION
- `do_rerun` was added to the objects but not actually retrieved from Experimenter API
- `do_rerun` also should trigger slightly different delete logic (only delete `overall` and always `recreate_enrollments`)
- tests