### PR TITLE
feat: non-clipping default version of lm mean statistic

### DIFF
--- a/jetstream/statistics.py
+++ b/jetstream/statistics.py
@@ -568,6 +568,18 @@ class LinearModelMean(Statistic):
 
 
 @attr.s(auto_attribs=True)
+class LinearModelMeanNoClip(LinearModelMean):
+    """Computes mean statistic using linear model. **No Clipping by default**
+
+    Parameters:
+    - drop_highest (float): Inherited and overridden from LinearModelMean. Default 0.0.
+    - covariate_adjustment (dict[str, str]): Inherited from LinearModelMean
+    """
+
+    drop_highest: float = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
+
+
+@attr.s(auto_attribs=True)
 class PerClientDAUImpact(LinearModelMean):
     """Computes the per-client DAU impact using linear model mean.
     Only returns relative uplift, strips absolute data points intentionally

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -116,6 +116,8 @@ class TestStatistics:
         assert treatment_result.upper
 
     def test_linear_model_mean_no_clip(self):
+        """Ensure that LinearModelMeanNoClip produces unclipped results
+        when LinearModelMean fails to produce results due to clipping."""
         stat = LinearModelMeanNoClip()
         assert stat.drop_highest == 0.0
         clipped_stat = LinearModelMean()
@@ -132,17 +134,18 @@ class TestStatistics:
             test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).root
         # clipped results should log a warning and return empty StatisticCollection
-        # because there all the non-zero data is clipped to zero as outliers
+        # because all the non-zero data is clipped to zero as outliers
         clipped_results = clipped_stat.transform(
             test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
         ).root
 
         # ensure:
-        # - no-clip should have results, and the values are deterministic
+        # - no-clip should have 4 results, and the values are as expected based on empirical testing
         # - clipped should have empty results
-        assert len(clipped_results) == 0
         assert len(results) == 4
+        assert len(clipped_results) == 0
 
+        # check the actual values for no-clip to avoid regressions
         for r in results:
             point = round(r.point, 3)
             lower = round(r.lower, 6)

--- a/jetstream/tests/test_statistics.py
+++ b/jetstream/tests/test_statistics.py
@@ -22,6 +22,7 @@ from jetstream.statistics import (
     EmpiricalCDF,
     KernelDensityEstimate,
     LinearModelMean,
+    LinearModelMeanNoClip,
     PerClientDAUImpact,
     PopulationRatio,
     StatisticResult,
@@ -113,6 +114,62 @@ class TestStatistics:
         assert treatment_result.point < control_result.point
         assert treatment_result.lower
         assert treatment_result.upper
+
+    def test_linear_model_mean_no_clip(self):
+        stat = LinearModelMeanNoClip()
+        assert stat.drop_highest == 0.0
+        clipped_stat = LinearModelMean()
+        assert clipped_stat.drop_highest == 0.005
+        # test_data contains all 0s except at the top 0.5%
+        test_data = pd.DataFrame(
+            {
+                "branch": ["control"] * 1000 + ["treatment"] * 1000,
+                "value": [0] * 996 + list(range(100, 104)) + [0] * 996 + list(range(100, 107, 2)),
+            }
+        )
+
+        results = stat.transform(
+            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
+        ).root
+        # clipped results should log a warning and return empty StatisticCollection
+        # because there all the non-zero data is clipped to zero as outliers
+        clipped_results = clipped_stat.transform(
+            test_data, "value", "control", None, AnalysisBasis.ENROLLMENTS, "all"
+        ).root
+
+        # ensure:
+        # - no-clip should have results, and the values are deterministic
+        # - clipped should have empty results
+        assert len(clipped_results) == 0
+        assert len(results) == 4
+
+        for r in results:
+            point = round(r.point, 3)
+            lower = round(r.lower, 6)
+            upper = round(r.upper, 6)
+            # absolute values
+            if r.comparison is None:
+                if r.branch == "treatment":
+                    assert point == 0.412
+                    assert lower == 0.008270
+                    assert upper == 0.815730
+                else:  # control
+                    assert point == 0.406
+                    assert lower == 0.008219
+                    assert upper == 0.803781
+
+            elif r.comparison == "difference":
+                assert point == 0.006
+                assert lower == -0.560426
+                assert upper == 0.572426
+
+            elif r.comparison == "relative_uplift":
+                assert point == 0.015
+                assert lower == -0.745768
+                assert upper == 3.050531
+
+            else:
+                pytest.fail("unexpected comparison!")
 
     def test_linear_model_mean_nullable_integer_dtype(self):
         """Metrics read from BigQuery can have pandas nullable Int64 dtype; the integer-dtype


### PR DESCRIPTION
Because
- there is interest in running linear model means without any threshold clipping as default behavior
- the default behavior is guided by the `drop_highest` parameter of `LinearModelMean`
- we don't want to replace the existing linear model mean behavior without validating

This commit
- adds a new `LinearModelMeanNoClip` statistic (referenced in configs as `linear_model_mean_no_config`) with default `drop_highest` of `0.0` that can be used alongside the existing `LinearModelMean` in configs


This PR will be followed by a metric-hub PR to add the new statistic to the guardrail(s) of the app(s) that @doomsuckle requests (with `[ci rerun-skip]` because we don't need/want to rerun every experiment). Once the metric-hub PR lands, it will be computed for future experiments, and available for past experiment reruns, both of which can be used for validation.